### PR TITLE
add to_object method for Bson

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bson"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Y. T. Chung <zonyitoo@gmail.com>"]
 description = "Encoding and decoding support for BSON in Rust"
 license = "MIT"

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -22,7 +22,8 @@
 //! BSON definition
 
 use chrono::{DateTime, UTC};
-use rustc_serialize::json;
+use rustc_serialize::json::{self,Decoder,DecodeResult};
+use rustc_serialize::Decodable;
 use rustc_serialize::hex::ToHex;
 
 use ordered::OrderedDocument;
@@ -159,6 +160,7 @@ impl From<DateTime<UTC>> for Bson {
     }
 }
 
+
 impl Bson {
     /// Get the `ElementType` of this value.
     pub fn element_type(&self) -> ElementType {
@@ -225,6 +227,10 @@ impl Bson {
             &Bson::ObjectId(ref v) => json::Json::String(v.bytes().to_hex()),
             &Bson::UtcDatetime(ref v) => json::Json::String(v.to_string()),
         }
+    }
+
+    pub fn to_object<T>(&self) -> DecodeResult<T> where T : Decodable {
+        T::decode(&mut Decoder::new(self.to_json()))
     }
 
     /// Create a `Bson` from a `Json`.

--- a/tests/modules/bson.rs
+++ b/tests/modules/bson.rs
@@ -1,0 +1,23 @@
+use bson::{Document,Bson};
+
+#[derive(RustcEncodable,RustcDecodable ,Debug , Clone, PartialEq, Eq)]
+pub struct User {
+    id: u64,
+    name : String
+}
+
+#[test]
+pub fn test_to_object(){
+    let mut doc = Document::new();
+    doc.insert("id".to_owned() , Bson::I64(10i64));
+    doc.insert("name".to_owned() , Bson::String("ZhuGe".to_owned()));
+
+    let bson = Bson::Document(doc);
+    match bson.to_object::<User>() {
+        Err(err) => panic!("{}" , err),
+        Ok(ref user) => {
+            println!("user : {:?}", user);
+            assert_eq!(user , &User{id : 10u64 , name : "ZhuGe".to_owned()});
+        }
+    }
+}

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -2,3 +2,4 @@ mod encoder;
 mod macros;
 mod oid;
 mod ordered;
+mod bson;


### PR DESCRIPTION
Before , user cannot directly convert bson to bussiness object ,but this is easy to do using the method `to_object` .