### PR TITLE
Format display

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -75,7 +75,7 @@ impl Display for Bson {
 
                 string.push_str("]");
                 string
-            },
+            }
             &Bson::Document(ref doc) => format!("{}", doc),
             &Bson::Boolean(b) => format!("{}", b),
             &Bson::Null => "null".to_owned(),
@@ -89,11 +89,8 @@ impl Display for Bson {
                 let inc = (i & 0xFFFFFFFF) as i32;
 
                 format!("Timestamp({}, {})", time, inc)
-            },
-            &Bson::Binary(t, ref vec) => {
-                let string = unsafe { str::from_utf8_unchecked(vec) };
-                format!("BinData({}, \"{}\")", u8::from(t), string)
             }
+            &Bson::Binary(t, ref vec) => format!("BinData({}, {})", u8::from(t), vec.to_hex()),
             &Bson::ObjectId(ref id) => {
                 let mut vec = vec![];
 

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -90,7 +90,7 @@ impl Display for Bson {
 
                 format!("Timestamp({}, {})", time, inc)
             }
-            &Bson::Binary(t, ref vec) => format!("BinData({}, {})", u8::from(t), vec.to_hex()),
+            &Bson::Binary(t, ref vec) => format!("BinData({}, 0x{})", u8::from(t), vec.to_hex()),
             &Bson::ObjectId(ref id) => {
                 let mut vec = vec![];
 

--- a/src/ordered.rs
+++ b/src/ordered.rs
@@ -1,5 +1,6 @@
 use bson::Bson;
 use std::collections::BTreeMap;
+use std::fmt::{Display, Error, Formatter};
 use std::iter::{FromIterator, Map};
 use std::vec::IntoIter;
 use std::slice;
@@ -9,6 +10,23 @@ use std::slice;
 pub struct OrderedDocument {
     pub keys: Vec<String>,
     document: BTreeMap<String, Bson>,
+}
+
+impl Display for OrderedDocument {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        let mut string = "{ ".to_owned();
+
+        for (key, value) in self.iter() {
+            if !string.eq("{ ") {
+                string.push_str(", ");
+            }
+
+            string.push_str(&format!("{}: {}", key, value));
+        }
+
+        string.push_str(" }");
+        fmt.write_str(&string)
+    }
 }
 
 /// An iterator over OrderedDocument entries.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -9,6 +9,7 @@ use bson::Bson;
 use bson::spec::BinarySubtype;
 use bson::oid::ObjectId;
 use chrono::offset::utc::UTC;
+use rustc_serialize::hex::ToHex;
 
 #[test]
 fn test_format() {
@@ -44,7 +45,7 @@ fn test_format() {
         "date" => (Bson::UtcDatetime(date))
     };
 
-    let expected = format!("{{ float: 2.4, string: \"hello\", array: [\"testing\", 1], doc: {{ fish: \"in\", a: \"barrel\", !: 1 }}, bool: true, null: null, regexp: /s[ao]d/i, code: function(x) {{ return x._id; }}, i32: 12, i64: -55, timestamp: Timestamp(0, 229999444), binary: BinData(5, \"thingies\"), _id: ObjectId(\"{}\"), date: Date(\"{}\") }}", id_string, date);
+    let expected = format!("{{ float: 2.4, string: \"hello\", array: [\"testing\", 1], doc: {{ fish: \"in\", a: \"barrel\", !: 1 }}, bool: true, null: null, regexp: /s[ao]d/i, code: function(x) {{ return x._id; }}, i32: 12, i64: -55, timestamp: Timestamp(0, 229999444), binary: BinData(5, {}), _id: ObjectId(\"{}\"), date: Date(\"{}\") }}", "thingies".as_bytes().to_hex(), id_string, date);
 
     assert_eq!(expected, format!("{}", doc));
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -45,7 +45,7 @@ fn test_format() {
         "date" => (Bson::UtcDatetime(date))
     };
 
-    let expected = format!("{{ float: 2.4, string: \"hello\", array: [\"testing\", 1], doc: {{ fish: \"in\", a: \"barrel\", !: 1 }}, bool: true, null: null, regexp: /s[ao]d/i, code: function(x) {{ return x._id; }}, i32: 12, i64: -55, timestamp: Timestamp(0, 229999444), binary: BinData(5, {}), _id: ObjectId(\"{}\"), date: Date(\"{}\") }}", "thingies".as_bytes().to_hex(), id_string, date);
+    let expected = format!("{{ float: 2.4, string: \"hello\", array: [\"testing\", 1], doc: {{ fish: \"in\", a: \"barrel\", !: 1 }}, bool: true, null: null, regexp: /s[ao]d/i, code: function(x) {{ return x._id; }}, i32: 12, i64: -55, timestamp: Timestamp(0, 229999444), binary: BinData(5, 0x{}), _id: ObjectId(\"{}\"), date: Date(\"{}\") }}", "thingies".as_bytes().to_hex(), id_string, date);
 
     assert_eq!(expected, format!("{}", doc));
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,4 +1,4 @@
-#[macro_use]
+#[macro_use(bson, doc)]
 extern crate bson;
 extern crate chrono;
 extern crate rustc_serialize;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,5 +1,50 @@
-#[macro_use(bson, doc)]
+#[macro_use]
 extern crate bson;
+extern crate chrono;
 extern crate rustc_serialize;
 
 mod modules;
+
+use bson::Bson;
+use bson::spec::BinarySubtype;
+use bson::oid::ObjectId;
+use chrono::offset::utc::UTC;
+
+#[test]
+fn test_format() {
+    let id_string = "thisismyname";
+    let string_bytes : Vec<_> = id_string.bytes().collect();
+    let mut bytes = [0; 12];
+
+    for i in 0..12 {
+        bytes[i] = string_bytes[i];
+    }
+
+    let id = ObjectId::with_bytes(bytes);
+    let date = UTC::now();
+
+    let doc = doc! {
+        "float" => 2.4,
+        "string" => "hello",
+        "array" => ["testing", 1],
+        "doc" => {
+            "fish" => "in",
+            "a" => "barrel",
+            "!" => 1
+        },
+        "bool" => true,
+        "null" => (Bson::Null),
+        "regexp" => (Bson::RegExp("s[ao]d".to_owned(), "i".to_owned())),
+        "code" => (Bson::JavaScriptCode("function(x) { return x._id; }".to_owned())),
+        "i32" => 12,
+        "i64" => (-55),
+        "timestamp" => (Bson::TimeStamp(229999444)),
+        "binary" => (Bson::Binary(BinarySubtype::Md5, "thingies".to_owned().into_bytes())),
+        "_id" => id,
+        "date" => (Bson::UtcDatetime(date))
+    };
+
+    let expected = format!("{{ float: 2.4, string: \"hello\", array: [\"testing\", 1], doc: {{ fish: \"in\", a: \"barrel\", !: 1 }}, bool: true, null: null, regexp: /s[ao]d/i, code: function(x) {{ return x._id; }}, i32: 12, i64: -55, timestamp: Timestamp(0, 229999444), binary: BinData(5, \"thingies\"), _id: ObjectId(\"{}\"), date: Date(\"{}\") }}", id_string, date);
+
+    assert_eq!(expected, format!("{}", doc));
+}


### PR DESCRIPTION
For the logging functionality in the MongoDB driver, we need to be able to print out documents in the format that they would appear in the shell. The ability to print the documents in a readable format would be useful for almost anyone using BSON, though.