### PR TITLE
Fix UtcDatetime en/decoding

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -25,7 +25,8 @@ use std::io::{self, Read};
 use std::{str, error, fmt};
 
 use byteorder::{self, LittleEndian, ReadBytesExt};
-use chrono::{DateTime, NaiveDateTime, UTC};
+use chrono::{UTC};
+use chrono::offset::TimeZone;
 
 use spec::{self, BinarySubtype};
 use bson::{Bson, Array, Document};
@@ -215,7 +216,7 @@ fn decode_bson<R: Read + ?Sized>(reader: &mut R, tag: u8) -> DecoderResult<Bson>
         Some(TimeStamp) => read_i64(reader).map(Bson::TimeStamp),
         Some(UtcDatetime) => {
             let time = try!(read_i64(reader));
-            Ok(Bson::UtcDatetime(DateTime::from_utc(NaiveDateTime::from_timestamp(time / 1000, 0), UTC)))
+            Ok(Bson::UtcDatetime(UTC.timestamp(time / 1000, (time % 1000) as u32 * 1000000)))
         },
 	Some(Deprecated) |
         Some(Undefined) |

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -215,7 +215,7 @@ fn decode_bson<R: Read + ?Sized>(reader: &mut R, tag: u8) -> DecoderResult<Bson>
         Some(TimeStamp) => read_i64(reader).map(Bson::TimeStamp),
         Some(UtcDatetime) => {
             let time = try!(read_i64(reader));
-            Ok(Bson::UtcDatetime(DateTime::from_utc(NaiveDateTime::from_timestamp(time, 0), UTC)))
+            Ok(Bson::UtcDatetime(DateTime::from_utc(NaiveDateTime::from_timestamp(time / 1000, 0), UTC)))
         },
 	Some(Deprecated) |
         Some(Undefined) |

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -24,6 +24,7 @@
 use std::io::{self, Write};
 use std::iter::IntoIterator;
 use std::{mem, error, fmt};
+use chrono::Timelike;
 
 use byteorder::{self, LittleEndian, WriteBytesExt};
 
@@ -162,7 +163,9 @@ fn encode_bson<W: Write + ?Sized>(writer: &mut W, key: &str, val: &Bson) -> Enco
             try!(writer.write_u8(From::from(subtype)));
             writer.write_all(data).map_err(From::from)
         },
-        &Bson::UtcDatetime(ref v) => write_i64(writer, v.timestamp() * 1000),
+        &Bson::UtcDatetime(ref v) => {
+            write_i64(writer, (v.timestamp() * 1000) + (v.nanosecond()  / 1000000)  as i64)
+        },
         &Bson::Null => Ok(())
     }
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -162,7 +162,7 @@ fn encode_bson<W: Write + ?Sized>(writer: &mut W, key: &str, val: &Bson) -> Enco
             try!(writer.write_u8(From::from(subtype)));
             writer.write_all(data).map_err(From::from)
         },
-        &Bson::UtcDatetime(ref v) => write_i64(writer, v.timestamp()),
+        &Bson::UtcDatetime(ref v) => write_i64(writer, v.timestamp() * 1000),
         &Bson::Null => Ok(())
     }
 }

--- a/tests/modules/encoder.rs
+++ b/tests/modules/encoder.rs
@@ -1,6 +1,9 @@
 extern crate bson;
+extern crate chrono;
 
 use bson::{Document, Bson, encode_document};
+use chrono::UTC;
+use chrono::offset::TimeZone;
 
 #[test]
 fn test_encode_floating_point() {
@@ -37,6 +40,19 @@ fn test_encode_array() {
 
     let mut doc = Document::new();
     doc.insert("key".to_owned(), Bson::Array(src));
+
+    let mut buf = Vec::new();
+    encode_document(&mut buf, &doc).unwrap();
+
+    assert_eq!(&buf[..], &dst[..]);
+}
+#[test]
+fn test_encode_utc_date_time() {
+    let src = UTC.timestamp(1286705410, 0);
+    let dst = [18, 0, 0, 0, 9, 107, 101, 121, 0, 208, 111, 158, 149, 43, 1, 0, 0, 0];
+
+    let mut doc = Document::new();
+    doc.insert("key".to_owned(), Bson::UtcDatetime(src));
 
     let mut buf = Vec::new();
     encode_document(&mut buf, &doc).unwrap();


### PR DESCRIPTION
Currently UtcDatetime is encoded as a `i64` from the chronos timestamp, however the chronos timestamp is returned in seconds since epoch(https://lifthrasiir.github.io/rust-chrono/chrono/datetime/struct.DateTime.html#method.timestamp).

According to the BSON spec a UtcDateTime should be encoded as miliseconds since epoch: http://bsonspec.org/spec.html

> UTC datetime - The int64 is UTC milliseconds since the Unix epoch.

This pull request attempts to solve this issue. 

(I've only been using rust for a few days now, so I'd love to know if this could be done better :))