### PR TITLE
Helpers to directly get inner values

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -32,7 +32,7 @@ use spec::{ElementType, BinarySubtype};
 use oid;
 
 /// Possible BSON value types.
-#[derive(Debug, Clone)]
+#[derive(Debug,Clone,PartialEq)]
 pub enum Bson {
     FloatingPoint(f64),
     String(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ extern crate time;
 pub use self::bson::{Bson, Document, Array};
 pub use self::encoder::{encode_document, EncoderResult, EncoderError};
 pub use self::decoder::{decode_document, DecoderResult, DecoderError};
+pub use self::ordered::{ValueAccessError, ValueAccessResult};
 
 pub mod macros;
 pub mod oid;

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -76,7 +76,7 @@ impl error::Error for Error {
     }
 
     fn cause(&self) -> Option<&error::Error> {
-        match self {            
+        match self {
             &Error::ArgumentError(_) => None,
             &Error::FromHexError(ref inner) => Some(inner),
             &Error::IoError(ref inner) => Some(inner),

--- a/tests/modules/ordered.rs
+++ b/tests/modules/ordered.rs
@@ -1,4 +1,7 @@
 use bson::{Bson, Document};
+use bson::ValueAccessError;
+use bson::oid::ObjectId;
+use chrono::UTC;
 
 #[test]
 fn ordered_insert() {
@@ -32,6 +35,66 @@ fn ordered_insert_shorthand() {
 
     let keys: Vec<_> = doc.iter().map(|(key, _)| key.to_owned()).collect();
     assert_eq!(expected_keys, keys);
+}
+
+#[test]
+fn test_getters() {
+    let datetime = UTC::now();
+    let cloned_dt = datetime.clone();
+    let mut doc = doc! {
+        "floating_point" => 10.0,
+        "string" => "a value",
+        "array" => [10, 20, 30],
+        "doc" => { "key" => 1 },
+        "bool" => true,
+        "i32" => 1i32,
+        "i64" => 1i64,
+        "datetime" => cloned_dt
+    };
+
+    assert_eq!(None, doc.get("nonsense"));
+    assert_eq!(Err(ValueAccessError::NotPresent), doc.get_str("nonsense"));
+    assert_eq!(Err(ValueAccessError::UnexpectedType), doc.get_str("floating_point"));
+
+    assert_eq!(Some(&Bson::FloatingPoint(10.0)), doc.get("floating_point"));
+    assert_eq!(Ok(10.0), doc.get_f64("floating_point"));
+
+    assert_eq!(Some(&Bson::String("a value".to_string())), doc.get("string"));
+    assert_eq!(Ok("a value"), doc.get_str("string"));
+
+    let array = vec![Bson::I32(10), Bson::I32(20), Bson::I32(30)];
+    assert_eq!(Some(&Bson::Array(array.clone())), doc.get("array"));
+    assert_eq!(Ok(&array), doc.get_array("array"));
+
+    let embedded = doc! { "key" => 1 };
+    assert_eq!(Some(&Bson::Document(embedded.clone())), doc.get("doc"));
+    assert_eq!(Ok(&embedded), doc.get_document("doc"));
+
+    assert_eq!(Some(&Bson::Boolean(true)), doc.get("bool"));
+    assert_eq!(Ok(true), doc.get_bool("bool"));
+
+    doc.insert("null".to_string(), Bson::Null);
+    assert_eq!(Some(&Bson::Null), doc.get("null"));
+    assert_eq!(true, doc.is_null("null"));
+    assert_eq!(false, doc.is_null("array"));
+
+    assert_eq!(Some(&Bson::I32(1)), doc.get("i32"));
+    assert_eq!(Ok(1i32), doc.get_i32("i32"));
+
+    assert_eq!(Some(&Bson::I64(1)), doc.get("i64"));
+    assert_eq!(Ok(1i64), doc.get_i64("i64"));
+
+    doc.insert("timestamp".to_string(), Bson::TimeStamp(100));
+    assert_eq!(Some(&Bson::TimeStamp(100)), doc.get("timestamp"));
+    assert_eq!(Ok(100i64), doc.get_time_stamp("timestamp"));
+
+    let object_id = ObjectId::new().unwrap();
+    doc.insert("_id".to_string(), Bson::ObjectId(object_id.clone()));
+    assert_eq!(Some(&Bson::ObjectId(object_id.clone())), doc.get("_id"));
+    assert_eq!(Ok(&object_id), doc.get_object_id("_id"));
+
+    assert_eq!(Some(&Bson::UtcDatetime(datetime.clone())), doc.get("datetime"));
+    assert_eq!(Ok(&datetime), doc.get_utc_datetime("datetime"));
 }
 
 #[test]


### PR DESCRIPTION
There's one annoyance left when working with the bson crate for our use case, getting to the inner typed values is quite verbose:

```rust
let truth = match document.get("truth") {
    Some(&Bson::Boolean(b)) => b,
    _ => panic!("truth is not a boolean")
};

let text = match document.get("text") {
    Some(&Bson::String(ref s)) => s,
    _ => panic!("text is not a string")
};
```

I've been thinking about a way to make this pattern more convenient. This pull is one way to go about it:

```rust
let truth = try!(document.get_bool("truth"));
let text = try!(document.get_str("text"));
```

Do you like this direction? If so I'll implement the remaining getters.