### PR TITLE
Allow string slices as keys for insertion

### DIFF
--- a/src/ordered.rs
+++ b/src/ordered.rs
@@ -190,16 +190,19 @@ impl OrderedDocument {
 
     /// Sets the value of the entry with the OccupiedEntry's key,
     /// and returns the entry's old value.
-    pub fn insert(&mut self, key: String, val: Bson) -> Option<Bson> {
-        let key_slice = &key[..];
+    pub fn insert<KT: Into<String>>(&mut self, key: KT, val: Bson) -> Option<Bson> {
+        let key = key.into();
 
-        if self.contains_key(key_slice) {
-            let position = self.position(key_slice).unwrap();
-            self.keys.remove(position);
+        {
+            let key_slice = &key[..];
+            if self.contains_key(key_slice) {
+                let position = self.position(key_slice).unwrap();
+                self.keys.remove(position);
+            }
         }
 
         self.keys.push(key.to_owned());
-        self.document.insert(key.to_owned(), val.to_owned())
+        self.document.insert(key, val.to_owned())
     }
 
     /// Takes the value of the entry out of the document, and returns it.

--- a/tests/modules/ordered.rs
+++ b/tests/modules/ordered.rs
@@ -11,7 +11,24 @@ fn ordered_insert() {
         "first".to_owned(),
         "second".to_owned(),
         "alphanumeric".to_owned(),
-        );
+    );
+
+    let keys: Vec<_> = doc.iter().map(|(key, _)| key.to_owned()).collect();
+    assert_eq!(expected_keys, keys);
+}
+
+#[test]
+fn ordered_insert_shorthand() {
+    let mut doc = Document::new();
+    doc.insert("first", Bson::I32(1));
+    doc.insert("second", Bson::String("foo".to_owned()));
+    doc.insert("alphanumeric", Bson::String("bar".to_owned()));
+
+    let expected_keys = vec!(
+        "first".to_owned(),
+        "second".to_owned(),
+        "alphanumeric".to_owned(),
+    );
 
     let keys: Vec<_> = doc.iter().map(|(key, _)| key.to_owned()).collect();
     assert_eq!(expected_keys, keys);


### PR DESCRIPTION
Another small ergonomics improvement. Before:

```rust
let mut doc = Document::new();
doc.insert("first".to_string(), Bson::I32(1));
```

After:
```rust
let mut doc = Document::new();
doc.insert("first", Bson::I32(1));
```

Also contains a minor performance improvement, removes one clone of the key.