### PR TITLE
Allow any type that converts into bson for insert

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -35,7 +35,7 @@ macro_rules! doc {
         let mut document = $crate::Document::new();
 
         $(
-            document.insert($key.to_owned(), bson!($val));
+            document.insert_bson($key.to_owned(), bson!($val));
         )*
 
         document

--- a/src/ordered.rs
+++ b/src/ordered.rs
@@ -189,10 +189,15 @@ impl OrderedDocument {
     }
 
     /// Sets the value of the entry with the OccupiedEntry's key,
-    /// and returns the entry's old value.
-    pub fn insert<KT: Into<String>>(&mut self, key: KT, val: Bson) -> Option<Bson> {
-        let key = key.into();
+    /// and returns the entry's old value. Accepts any type that
+    /// can be converted into Bson.
+    pub fn insert<KT: Into<String>, BT: Into<Bson>>(&mut self, key: KT, val: BT) -> Option<Bson> {
+        self.insert_bson(key.into(), val.into())
+    }
 
+    /// Sets the value of the entry with the OccupiedEntry's key,
+    /// and returns the entry's old value.
+    pub fn insert_bson(&mut self, key: String, val: Bson) -> Option<Bson> {
         {
             let key_slice = &key[..];
             if self.contains_key(key_slice) {

--- a/tests/modules/ordered.rs
+++ b/tests/modules/ordered.rs
@@ -20,9 +20,9 @@ fn ordered_insert() {
 #[test]
 fn ordered_insert_shorthand() {
     let mut doc = Document::new();
-    doc.insert("first", Bson::I32(1));
-    doc.insert("second", Bson::String("foo".to_owned()));
-    doc.insert("alphanumeric", Bson::String("bar".to_owned()));
+    doc.insert("first", 1i32);
+    doc.insert("second", "foo");
+    doc.insert("alphanumeric", "bar".to_owned());
 
     let expected_keys = vec!(
         "first".to_owned(),


### PR DESCRIPTION
Another convenience improvement. Before:

```rust
let mut doc = Document::new();
doc.insert("first", Bson::I32(1));
```
After:
```rust
let mut doc = Document::new();
doc.insert("first", 1i32);
```

Don't worry, I think I'm done now :-P.