### PR TITLE
Fix String conversion cases

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -127,6 +127,12 @@ impl<'a> From<&'a str> for Bson {
 
 impl From<String> for Bson {
     fn from(a: String) -> Bson {
+        Bson::String(a)
+    }
+}
+
+impl<'a> From<&'a String> for Bson {
+    fn from(a: &'a String) -> Bson {
         Bson::String(a.to_owned())
     }
 }


### PR DESCRIPTION
First fix `From<String>`: no need to get owning when you own object inside conversion.
Second fix `From<&String>`: useful when content already has borrowed by `ref` keyword.