### PR TITLE
Improved ObjectId and Bson display

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -58,43 +58,43 @@ pub type Document = OrderedDocument;
 
 impl Display for Bson {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        let bson_string = match self {
-            &Bson::FloatingPoint(f) => format!("{}", f),
-            &Bson::String(ref s) => format!("\"{}\"", s),
+        match self {
+            &Bson::FloatingPoint(f) => write!(fmt, "{}", f),
+            &Bson::String(ref s) => write!(fmt, "\"{}\"", s),
             &Bson::Array(ref vec) => {
-                let mut string = "[".to_owned();
+                try!(write!(fmt, "["));
 
+                let mut first = true;
                 for bson in vec.iter() {
-                    if !string.eq("[") {
-                        string.push_str(", ");
+                    if !first {
+                        try!(write!(fmt, ", "));
                     }
 
-                    string.push_str(&format!("{}", bson));
+                    try!(write!(fmt, "{}", bson));
+                    first = false;
                 }
 
-                string.push_str("]");
-                string
+                write!(fmt, "]")
             }
-            &Bson::Document(ref doc) => format!("{}", doc),
-            &Bson::Boolean(b) => format!("{}", b),
-            &Bson::Null => "null".to_owned(),
-            &Bson::RegExp(ref pat, ref opt) => format!("/{}/{}", pat, opt),
+            &Bson::Document(ref doc) => write!(fmt, "{}", doc),
+            &Bson::Boolean(b) => write!(fmt, "{}", b),
+            &Bson::Null => write!(fmt, "null"),
+            &Bson::RegExp(ref pat, ref opt) => write!(fmt, "/{}/{}", pat, opt),
             &Bson::JavaScriptCode(ref s) |
-            &Bson::JavaScriptCodeWithScope(ref s, _) => s.to_owned(),
-            &Bson::I32(i) => format!("{}", i),
-            &Bson::I64(i) => format!("{}", i),
+            &Bson::JavaScriptCodeWithScope(ref s, _) => fmt.write_str(&s),
+            &Bson::I32(i) => write!(fmt, "{}", i),
+            &Bson::I64(i) => write!(fmt, "{}", i),
             &Bson::TimeStamp(i) => {
                 let time = (i >> 32) as i32;
                 let inc = (i & 0xFFFFFFFF) as i32;
 
-                format!("Timestamp({}, {})", time, inc)
+                write!(fmt, "Timestamp({}, {})", time, inc)
             }
-            &Bson::Binary(t, ref vec) => format!("BinData({}, 0x{})", u8::from(t), vec.to_hex()),
-            &Bson::ObjectId(ref id) => format!("ObjectId(\"{}\")", id),
-            &Bson::UtcDatetime(date_time) => format!("Date(\"{}\")", date_time)
-        };
-
-        fmt.write_str(&bson_string)
+            &Bson::Binary(t, ref vec) =>
+                write!(fmt, "BinData({}, 0x{})", u8::from(t), vec.to_hex()),
+            &Bson::ObjectId(ref id) => write!(fmt, "ObjectId(\"{}\")", id),
+            &Bson::UtcDatetime(date_time) => write!(fmt, "Date(\"{}\")", date_time)
+        }
     }
 }
 

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -90,16 +90,7 @@ impl Display for Bson {
                 format!("Timestamp({}, {})", time, inc)
             }
             &Bson::Binary(t, ref vec) => format!("BinData({}, 0x{})", u8::from(t), vec.to_hex()),
-            &Bson::ObjectId(ref id) => {
-                let mut vec = vec![];
-
-                for byte in id.bytes().iter() {
-                    vec.push(byte.to_owned());
-                }
-
-                let string = unsafe { String::from_utf8_unchecked(vec) };
-                format!("ObjectId(\"{}\")", string)
-            }
+            &Bson::ObjectId(ref id) => format!("ObjectId(\"{}\")", id),
             &Bson::UtcDatetime(date_time) => format!("Date(\"{}\")", date_time)
         };
 

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -146,11 +146,6 @@ impl ObjectId {
         self.id
     }
 
-    /// Returns a 12-byte (24-char) hexadecimal string
-    pub fn to_string(&self) -> String {
-        self.id.to_hex()
-    }
-
     /// Retrieves the timestamp (seconds since epoch) from an ObjectId.
     pub fn timestamp(&self) -> u32 {
         BigEndian::read_u32(&self.id)
@@ -268,6 +263,18 @@ impl ObjectId {
         BigEndian::write_u64(&mut buf, u_int);
         let buf_u24: [u8; 3] = [buf[5], buf[6], buf[7]];
         Ok(buf_u24)
+    }
+}
+
+impl ToHex for ObjectId {
+    fn to_hex(&self) -> String {
+        self.id.to_hex()
+    }
+}
+
+impl fmt::Display for ObjectId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.to_hex())
     }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -45,7 +45,7 @@ fn test_format() {
         "date" => (Bson::UtcDatetime(date))
     };
 
-    let expected = format!("{{ float: 2.4, string: \"hello\", array: [\"testing\", 1], doc: {{ fish: \"in\", a: \"barrel\", !: 1 }}, bool: true, null: null, regexp: /s[ao]d/i, code: function(x) {{ return x._id; }}, i32: 12, i64: -55, timestamp: Timestamp(0, 229999444), binary: BinData(5, 0x{}), _id: ObjectId(\"{}\"), date: Date(\"{}\") }}", "thingies".as_bytes().to_hex(), id_string, date);
+    let expected = format!("{{ float: 2.4, string: \"hello\", array: [\"testing\", 1], doc: {{ fish: \"in\", a: \"barrel\", !: 1 }}, bool: true, null: null, regexp: /s[ao]d/i, code: function(x) {{ return x._id; }}, i32: 12, i64: -55, timestamp: Timestamp(0, 229999444), binary: BinData(5, 0x{}), _id: ObjectId(\"{}\"), date: Date(\"{}\") }}", "thingies".as_bytes().to_hex(), id_string.as_bytes().to_hex(), date);
 
     assert_eq!(expected, format!("{}", doc));
 }


### PR DESCRIPTION
Existing `ObjectId` display inside `Bson` is unsafe - it uses `from_utf8_unchecked()` when it has no right to do so, because the bytes contained inside `ObjectId` are absolutely not guaranteed to form valid UTF-8 data.

This PR makes `Display` implementation for `Bson` to delegate to `ObjectId`'s `Display` implementation, printing it as a hex string. Additionally, `Display` implementation for `Bson` is optimized in order not to allocate more than necessary.

Note that even though I've removed inherent `to_string()` method on `ObjectId`, its API is not broken because `to_string()` is now available through the `Display` implementation and it gives the same result as before.