### PR TITLE
Update to serde 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ libc = "0.1"
 rand = "0.3"
 rust-crypto = "0.2.31"
 rustc-serialize = "0.3"
-serde = "0.7"
+serde = "0.8"
 time = "0.1"
 linked-hash-map = "0.0.9"
 

--- a/src/decoder/serde.rs
+++ b/src/decoder/serde.rs
@@ -145,6 +145,43 @@ impl Decoder {
     }
 }
 
+macro_rules! forward_to_deserialize {
+    ($(
+        $name:ident ( $( $arg:ident : $ty:ty ),* );
+    )*) => {
+        $(
+            forward_to_deserialize!{
+                func: $name ( $( $arg: $ty ),* );
+            }
+        )*
+    };
+
+    (func: deserialize_enum ( $( $arg:ident : $ty:ty ),* );) => {
+        fn deserialize_enum<V>(
+            &mut self,
+            $(_: $ty,)*
+            _visitor: V,
+        ) -> ::std::result::Result<V::Value, Self::Error>
+            where V: ::serde::de::EnumVisitor
+        {
+            Err(::serde::de::Error::invalid_type(::serde::de::Type::Enum))
+        }
+    };
+
+    (func: $name:ident ( $( $arg:ident : $ty:ty ),* );) => {
+        #[inline]
+        fn $name<V>(
+            &mut self,
+            $(_: $ty,)*
+            visitor: V,
+        ) -> ::std::result::Result<V::Value, Self::Error>
+            where V: ::serde::de::Visitor
+        {
+            self.deserialize(visitor)
+        }
+    };
+}
+
 impl Deserializer for Decoder {
     type Error = DecoderError;
 
@@ -244,6 +281,36 @@ impl Deserializer for Decoder {
     {
         visitor.visit_newtype_struct(self)
     }
+
+    forward_to_deserialize!{
+        deserialize_bool();
+        deserialize_usize();
+        deserialize_u8();
+        deserialize_u16();
+        deserialize_u32();
+        deserialize_u64();
+        deserialize_isize();
+        deserialize_i8();
+        deserialize_i16();
+        deserialize_i32();
+        deserialize_i64();
+        deserialize_f32();
+        deserialize_f64();
+        deserialize_char();
+        deserialize_str();
+        deserialize_string();
+        deserialize_unit();
+        deserialize_seq();
+        deserialize_seq_fixed_size(len: usize);
+        deserialize_bytes();
+        deserialize_map();
+        deserialize_unit_struct(name: &'static str);
+        deserialize_tuple_struct(name: &'static str, len: usize);
+        deserialize_struct(name: &'static str, fields: &'static [&'static str]);
+        deserialize_struct_field();
+        deserialize_tuple(len: usize);
+        deserialize_ignored_any();
+    }
 }
 
 struct VariantDecoder<'a> {
@@ -334,6 +401,39 @@ impl<'a> Deserializer for SeqDecoder<'a> {
         } else {
             visitor.visit_seq(self)
         }
+    }
+
+    forward_to_deserialize!{
+        deserialize_bool();
+        deserialize_usize();
+        deserialize_u8();
+        deserialize_u16();
+        deserialize_u32();
+        deserialize_u64();
+        deserialize_isize();
+        deserialize_i8();
+        deserialize_i16();
+        deserialize_i32();
+        deserialize_i64();
+        deserialize_f32();
+        deserialize_f64();
+        deserialize_char();
+        deserialize_str();
+        deserialize_string();
+        deserialize_unit();
+        deserialize_option();
+        deserialize_seq();
+        deserialize_seq_fixed_size(len: usize);
+        deserialize_bytes();
+        deserialize_map();
+        deserialize_unit_struct(name: &'static str);
+        deserialize_newtype_struct(name: &'static str);
+        deserialize_tuple_struct(name: &'static str, len: usize);
+        deserialize_struct(name: &'static str, fields: &'static [&'static str]);
+        deserialize_struct_field();
+        deserialize_tuple(len: usize);
+        deserialize_enum(name: &'static str, variants: &'static [&'static str]);
+        deserialize_ignored_any();
     }
 }
 
@@ -428,6 +528,38 @@ impl<'a> MapVisitor for MapDecoder<'a> {
             {
                 visitor.visit_none()
             }
+
+            forward_to_deserialize!{
+                deserialize_bool();
+                deserialize_usize();
+                deserialize_u8();
+                deserialize_u16();
+                deserialize_u32();
+                deserialize_u64();
+                deserialize_isize();
+                deserialize_i8();
+                deserialize_i16();
+                deserialize_i32();
+                deserialize_i64();
+                deserialize_f32();
+                deserialize_f64();
+                deserialize_char();
+                deserialize_str();
+                deserialize_string();
+                deserialize_unit();
+                deserialize_newtype_struct(name: &'static str);
+                deserialize_seq();
+                deserialize_seq_fixed_size(len: usize);
+                deserialize_bytes();
+                deserialize_map();
+                deserialize_unit_struct(name: &'static str);
+                deserialize_tuple_struct(name: &'static str, len: usize);
+                deserialize_struct(name: &'static str, fields: &'static [&'static str]);
+                deserialize_struct_field();
+                deserialize_tuple(len: usize);
+                deserialize_enum(name: &'static str, variants: &'static [&'static str]);
+                deserialize_ignored_any();
+            }
         }
 
         Ok(try!(Deserialize::deserialize(&mut UnitDecoder)))
@@ -446,5 +578,38 @@ impl<'a> Deserializer for MapDecoder<'a> {
         where V: Visitor,
     {
         visitor.visit_map(self)
+    }
+
+    forward_to_deserialize!{
+        deserialize_bool();
+        deserialize_usize();
+        deserialize_u8();
+        deserialize_u16();
+        deserialize_u32();
+        deserialize_u64();
+        deserialize_isize();
+        deserialize_i8();
+        deserialize_i16();
+        deserialize_i32();
+        deserialize_i64();
+        deserialize_f32();
+        deserialize_f64();
+        deserialize_char();
+        deserialize_str();
+        deserialize_string();
+        deserialize_unit();
+        deserialize_option();
+        deserialize_seq();
+        deserialize_seq_fixed_size(len: usize);
+        deserialize_bytes();
+        deserialize_map();
+        deserialize_unit_struct(name: &'static str);
+        deserialize_newtype_struct(name: &'static str);
+        deserialize_tuple_struct(name: &'static str, len: usize);
+        deserialize_struct(name: &'static str, fields: &'static [&'static str]);
+        deserialize_struct_field();
+        deserialize_tuple(len: usize);
+        deserialize_enum(name: &'static str, variants: &'static [&'static str]);
+        deserialize_ignored_any();
     }
 }

--- a/src/encoder/error.rs
+++ b/src/encoder/error.rs
@@ -1,15 +1,13 @@
 use std::{io, error, fmt};
 use byteorder;
 use serde::ser;
-use super::serde::State;
+use bson::Bson;
 
 /// Possible errors that can arise during encoding.
 #[derive(Debug)]
 pub enum EncoderError {
     IoError(io::Error),
-    InvalidMapKeyType(State),
-    InvalidState(State),
-    EmptyState,
+    InvalidMapKeyType(Bson),
     Unknown(String),
 }
 
@@ -29,9 +27,7 @@ impl fmt::Display for EncoderError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {
             &EncoderError::IoError(ref inner) => inner.fmt(fmt),
-            &EncoderError::InvalidMapKeyType(ref inner) => write!(fmt, "Invalid map key type: {:?}", inner),
-            &EncoderError::InvalidState(ref inner) => write!(fmt, "Invalid state emitted: {:?}", inner),
-            &EncoderError::EmptyState => write!(fmt, "No state emitted"),
+            &EncoderError::InvalidMapKeyType(ref bson) => write!(fmt, "Invalid map key type: {:?}", bson),
             &EncoderError::Unknown(ref inner) => inner.fmt(fmt),
         }
     }
@@ -42,8 +38,6 @@ impl error::Error for EncoderError {
         match self {
             &EncoderError::IoError(ref inner) => inner.description(),
             &EncoderError::InvalidMapKeyType(_) => "Invalid map key type",
-            &EncoderError::InvalidState(_) => "Invalid state emitted",
-            &EncoderError::EmptyState => "No state emitted",
             &EncoderError::Unknown(ref inner) => inner,
         }
     }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,56 @@
+#[macro_use]
+extern crate bson;
+use bson::{Encoder, Decoder};
+
+extern crate serde;
+use serde::{Serialize, Deserialize};
+
+use std::collections::BTreeMap;
+
+#[test]
+fn test_ser_vec() {
+    let vec = vec![1, 2, 3];
+
+    let mut encoder = Encoder::new();
+    vec.serialize(&mut encoder).unwrap();
+
+    let expected = bson!([1, 2, 3]);
+    assert_eq!(expected, encoder.bson().unwrap());
+}
+
+#[test]
+fn test_ser_map() {
+    let mut map = BTreeMap::new();
+    map.insert("x", 0);
+    map.insert("y", 1);
+
+    let mut encoder = Encoder::new();
+    map.serialize(&mut encoder).unwrap();
+
+    let expected = bson!({ "x" => 0, "y" => 1 });
+    assert_eq!(expected, encoder.bson().unwrap());
+}
+
+#[test]
+fn test_de_vec() {
+    let bson = bson!([1, 2, 3]);
+
+    let mut decoder = Decoder::new(bson);
+    let vec = Vec::<i32>::deserialize(&mut decoder).unwrap();
+
+    let expected = vec![1, 2, 3];
+    assert_eq!(expected, vec);
+}
+
+#[test]
+fn test_de_map() {
+    let bson = bson!({ "x" => 0, "y" => 1 });
+
+    let mut decoder = Decoder::new(bson);
+    let map = BTreeMap::<String, i32>::deserialize(&mut decoder).unwrap();
+
+    let mut expected = BTreeMap::new();
+    expected.insert("x".to_string(), 0);
+    expected.insert("y".to_string(), 1);
+    assert_eq!(expected, map);
+}


### PR DESCRIPTION
The biggest change is the new Serializer API which provides a better way to handle what used to be `Vec<State>` inside `Encoder`.

Before:

```rust
#[inline]
fn serialize_seq<V>(&mut self, mut visitor: V) -> EncoderResult<()>
    where V: SeqVisitor,
{
    let len = visitor.len().unwrap_or(0);
    let values = Vec::with_capacity(len);
    self.state.push(State::Array(values));

    while let Some(()) = try!(visitor.visit(self)) { }

    let values = match try!(self.pop()) {
        State::Array(values) => values,
        state => return Err(EncoderError::InvalidState(state)),
    };

    self.state.push(State::Bson(Bson::Array(values)));
    Ok(())
}

#[inline]
fn serialize_seq_elt<T>(&mut self, value: T) -> EncoderResult<()>
    where T: Serialize,
{
    try!(value.serialize(self));

    let value = match try!(self.pop()) {
        State::Bson(value) => value,
        state => return Err(EncoderError::InvalidState(state)),
    };

    match self.state.last_mut() {
        Some(&mut State::Array(ref mut values)) => values.push(value),
        Some(state) => return Err(EncoderError::InvalidState(state.clone())),
        None => return Err(EncoderError::EmptyState),
    }

    Ok(())
}
```

After

```rust
#[inline]
fn serialize_seq(&mut self, len: Option<usize>) -> EncoderResult<Array> {
    Ok(Array::with_capacity(len.unwrap_or(0)))
}

#[inline]
fn serialize_seq_elt<T>(&mut self,
                        state: &mut Array,
                        value: T) -> EncoderResult<()>
    where T: Serialize,
{
    state.push(try!(to_bson(&value)));
    Ok(())
}

#[inline]
fn serialize_seq_end(&mut self, state: Array) -> EncoderResult<()> {
    self.value = Bson::Array(state);
    Ok(())
}
```