### PR TITLE
Fix JavaScriptCodeWithScope encoding and decoding

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -152,6 +152,10 @@ fn decode_bson<R: Read + ?Sized>(reader: &mut R, tag: u8) -> DecoderResult<Bson>
         },
         Some(JavaScriptCode) => read_string(reader).map(Bson::JavaScriptCode),
         Some(JavaScriptCodeWithScope) => {
+            // disregard the length:
+            //     using Read::take causes infinite type recursion
+            try!(read_i32(reader));
+
             let code = try!(read_string(reader));
             let scope = try!(decode_document(reader));
             Ok(Bson::JavaScriptCodeWithScope(code, scope))

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -117,7 +117,7 @@ fn encode_bson<W: Write + ?Sized>(writer: &mut W, key: &str, val: &Bson) -> Enco
             try!(write_string(&mut buf, code));
             try!(encode_document(&mut buf, scope));
 
-            try!(write_i32(writer, buf.len() as i32 + 1));
+            try!(write_i32(writer, buf.len() as i32 + 4));
             writer.write_all(&buf).map_err(From::from)
         },
         &Bson::I32(v) => write_i32(writer, v),

--- a/tests/modules/encoder_decoder.rs
+++ b/tests/modules/encoder_decoder.rs
@@ -148,8 +148,8 @@ fn test_encode_decode_javascript_code_with_scope() {
 
     assert_eq!(buf, dst);
 
-    //let decoded = decode_document(&mut Cursor::new(buf)).unwrap();
-    //assert_eq!(decoded, doc);
+    let decoded = decode_document(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(decoded, doc);
 }
 
 #[test]

--- a/tests/modules/encoder_decoder.rs
+++ b/tests/modules/encoder_decoder.rs
@@ -136,21 +136,21 @@ fn test_encode_decode_javascript_code() {
     assert_eq!(decoded, doc);
 }
 
-//#[test]
-//fn test_encode_decode_javascript_code_with_scope() {
-//    let src = Bson::JavaScriptCodeWithScope("1".to_owned(), doc!{});
-//    let dst = vec![25, 0, 0, 0, 15, 107, 101, 121, 0, 12, 0, 0, 0, 2, 0, 0, 0, 49, 0, 5, 0, 0, 0, 0, 0];
-//
-//    let doc = doc!{ "key" => src };
-//
-//    let mut buf = Vec::new();
-//    encode_document(&mut buf, &doc).unwrap();
-//
-//    assert_eq!(buf, dst);
-//
-//    let decoded = decode_document(&mut Cursor::new(buf)).unwrap();
-//    assert_eq!(decoded, doc);
-//}
+#[test]
+fn test_encode_decode_javascript_code_with_scope() {
+    let src = Bson::JavaScriptCodeWithScope("1".to_owned(), doc!{});
+    let dst = vec![25, 0, 0, 0, 15, 107, 101, 121, 0, 15, 0, 0, 0, 2, 0, 0, 0, 49, 0, 5, 0, 0, 0, 0, 0];
+
+    let doc = doc!{ "key" => src };
+
+    let mut buf = Vec::new();
+    encode_document(&mut buf, &doc).unwrap();
+
+    assert_eq!(buf, dst);
+
+    //let decoded = decode_document(&mut Cursor::new(buf)).unwrap();
+    //assert_eq!(decoded, doc);
+}
 
 #[test]
 fn test_encode_decode_i32() {


### PR DESCRIPTION
In the bson spec, a `code_w_s` object is defined as:
```
code_w_s 	::= 	int32 string document 	Code w/ scope
```

On the decoding side, that means we have to read off an `i32` before reading `string` or `document`. On the encoding side, that means we have to add `+4` to the buffer length instead of `+1` (because an i32 is 4 bytes). I tested that this behavior matches up with the golang mongo driver (mgo).