### PR TITLE
Fix json f64 value conversion

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -320,7 +320,7 @@ impl Bson {
         match j {
             &Value::Number(ref x) =>
                 x.as_i64().map(Bson::from)
-                .or(x.as_f64().map(Bson::from))
+                .or_else(|| x.as_f64().map(Bson::from))
                 .expect(&format!("Invalid number value: {}", x)),
             &Value::String(ref x) => x.into(),
             &Value::Bool(x) => x.into(),

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -320,7 +320,7 @@ impl Bson {
         match j {
             &Value::Number(ref x) =>
                 x.as_i64().map(Bson::from)
-                .or(x.as_u64().map(Bson::from))
+                .or(x.as_f64().map(Bson::from))
                 .expect(&format!("Invalid number value: {}", x)),
             &Value::String(ref x) => x.into(),
             &Value::Bool(x) => x.into(),


### PR DESCRIPTION
Hello! After switching over to serde_json, I noticed a small discrepancy in converting numerical values to Bson. 

Looking at the [Number code](https://github.com/serde-rs/json/blob/master/json/src/number.rs#L55-L63), `as_i64` will cast unsigned values to i64, while floating points will return `None`, so we are missing the floating-point conversion here.