### PR TITLE
Implement From/Into traits for Value

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -355,20 +355,23 @@ impl Bson {
         }
     }
 
-    // Clones the bson and returns the representative serde_json Value.
-    // The json will be in [extended JSON format](https://docs.mongodb.com/manual/reference/mongodb-extended-json/).
+    /// Clones the bson and returns the representative serde_json Value.
+    /// The json will be in [extended JSON format](https://docs.mongodb.com/manual/reference/mongodb-extended-json/).
+    #[deprecated(since="0.5.1", note="use bson.clone().into() instead")]
     pub fn to_json(&self) -> Value {
         self.clone().into()
     }
 
-    // Consumes the bson and returns the representative serde_json Value.
-    // The json will be in [extended JSON format](https://docs.mongodb.com/manual/reference/mongodb-extended-json/).
+    /// Consumes the bson and returns the representative serde_json Value.
+    /// The json will be in [extended JSON format](https://docs.mongodb.com/manual/reference/mongodb-extended-json/).
+    #[deprecated(since="0.5.1", note="use bson.into() instead")]
     pub fn into_json(self) -> Value {
         self.into()
     }
 
-    // Consumes the serde_json Value and returns the representative bson.
-    // The json should be in [extended JSON format](https://docs.mongodb.com/manual/reference/mongodb-extended-json/).
+    /// Consumes the serde_json Value and returns the representative bson.
+    /// The json should be in [extended JSON format](https://docs.mongodb.com/manual/reference/mongodb-extended-json/).
+    #[deprecated(since="0.5.1", note="use json.into() instead")]
     pub fn from_json(val: Value) -> Bson {
         val.into()
     }

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -302,7 +302,7 @@ impl Into<Value> for Bson {
                     "$code": code,
                     "scope": scope
                 })
-            },
+            }
             Bson::I32(v) => v.into(),
             Bson::I64(v) => v.into(),
             Bson::TimeStamp(v) => {
@@ -312,14 +312,14 @@ impl Into<Value> for Bson {
                     "t": time,
                     "i": inc
                 })
-            },
+            }
             Bson::Binary(t, ref v) => {
                 let tval: u8 = From::from(t);
                 json!({
                     "type": tval,
                     "$binary": v.to_hex()
                 })
-            },
+            }
             Bson::ObjectId(v) => json!({"$oid": v.to_string()}),
             Bson::UtcDatetime(v) => json!({
                 "$date": {


### PR DESCRIPTION
This makes things a little more convenient by allowing us to call `bson_val.into()`, `json_val.into()`, etc, and giving us a more performant, consuming transformation method.

This also allows us to plug bson values into any interface that relies on `From<Value>` or `Into<Value>`.

Keeping `from_json`, `to_json` for backwards-compatibility, and adding an appropriate `into_json` consumer.