### PR TITLE
add function to get length when decoding bson document

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,8 @@ extern crate hex;
 
 pub use self::bson::{Bson, Document, Array, UtcDateTime};
 pub use self::encoder::{encode_document, to_bson, Encoder, EncoderResult, EncoderError};
-pub use self::decoder::{decode_document, from_bson, Decoder, DecoderResult, DecoderError};
+pub use self::decoder::{decode_document, decode_document_and_get_length, from_bson, Decoder,
+                        DecoderResult, DecoderError};
 pub use self::ordered::{ValueAccessError, ValueAccessResult};
 
 #[macro_use]


### PR DESCRIPTION
Currently, there isn't any way to get the length of a BSON document when decoding it . I rediscovered that we're doing an [inefficient hack](https://github.com/mongodb-labs/mongo-rust-driver-prototype/blob/58d28bbec006b42f509812cdfd7c92bfb18cb843/src/wire_protocol/operations.rs#L25) in the MongoDB driver to be able to get the byte length of documents, so adding this functionality should allow us to make some optimizations (i.e. not [re-encode everything we decode](https://github.com/mongodb-labs/mongo-rust-driver-prototype/blob/58d28bbec006b42f509812cdfd7c92bfb18cb843/src/wire_protocol/operations.rs#L529)).