### PR TITLE
Add decode_document_utf8_lossy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ extern crate hex;
 
 pub use self::bson::{Bson, Document, Array, UtcDateTime};
 pub use self::encoder::{encode_document, to_bson, Encoder, EncoderResult, EncoderError};
-pub use self::decoder::{decode_document, from_bson, Decoder, DecoderResult, DecoderError};
+pub use self::decoder::{decode_document, decode_document_utf8_lossy, from_bson, Decoder, DecoderResult, DecoderError};
 pub use self::ordered::{ValueAccessError, ValueAccessResult};
 
 #[macro_use]

--- a/tests/modules/encoder_decoder.rs
+++ b/tests/modules/encoder_decoder.rs
@@ -1,5 +1,5 @@
 use std::io::Cursor;
-use bson::{Bson, decode_document, encode_document};
+use bson::{Bson, decode_document, decode_document_utf8_lossy, encode_document};
 use bson::oid::ObjectId;
 use bson::spec::BinarySubtype;
 use chrono::Utc;
@@ -36,6 +36,21 @@ fn test_encode_decode_utf8_string() {
 
     let decoded = decode_document(&mut Cursor::new(buf)).unwrap();
     assert_eq!(decoded, doc);
+}
+
+#[test]
+fn test_encode_decode_utf8_string_invalid() {
+    let bytes = b"\x80\xae".to_vec();
+    let src = unsafe { String::from_utf8_unchecked(bytes) };
+
+    let doc = doc!{ "key": src };
+
+    let mut buf = Vec::new();
+    encode_document(&mut buf, &doc).unwrap();
+
+    let expected = doc!{ "key": "��" };
+    let decoded = decode_document_utf8_lossy(&mut Cursor::new(buf)).unwrap();
+    assert_eq!(decoded, expected);
 }
 
 #[test]


### PR DESCRIPTION
MongoDB has a bug where it can return bson responses that contain strings with invalid UTF-8 encoding: https://jira.mongodb.org/browse/SERVER-24007

This bug has been open since 2016 and no fix is in sight, so we need a workaround in the `mongo_driver` crate. This commit adds a separate decode function that allows you to get lossy UTF-8 conversion. We will use this function when parsing error responses from Mongo.