### PR TITLE
add entry API for Document

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rust-crypto = "0.2"
 serde = "1.0"
 serde_json = { version = "1.0.0", features = ["preserve_order"] }
 time = "0.1"
-linked-hash-map = "0.3"
+linked-hash-map = "0.5"
 hostname = "^0.1"
 hex = "^0.2"
 

--- a/src/ordered.rs
+++ b/src/ordered.rs
@@ -354,6 +354,30 @@ impl OrderedDocument {
     pub fn remove(&mut self, key: &str) -> Option<Bson> {
         self.inner.remove(key)
     }
+
+    pub fn entry(&mut self, k: String) -> Entry {
+        Entry {
+            inner: self.inner.entry(k),
+        }
+    }
+}
+
+pub struct Entry<'a> {
+    inner: linked_hash_map::Entry<'a, String, Bson>,
+}
+
+impl<'a> Entry<'a> {
+    pub fn key(&self) -> &str {
+        self.inner.key()
+    }
+
+    pub fn or_insert(self, default: Bson) -> &'a mut Bson {
+        self.inner.or_insert(default)
+    }
+
+    pub fn or_insert_with<F: FnOnce() -> Bson>(self, default: F) -> &'a mut Bson {
+        self.inner.or_insert_with(default)
+    }
 }
 
 impl From<LinkedHashMap<String, Bson>> for OrderedDocument {

--- a/tests/modules/ordered.rs
+++ b/tests/modules/ordered.rs
@@ -121,3 +121,38 @@ fn remove() {
     let keys: Vec<_> = doc.iter().map(|(key, _)| key.to_owned()).collect();
     assert_eq!(expected_keys, keys);
 }
+
+#[test]
+fn entry() {
+    let mut doc = doc! {
+        "first": 1i32,
+        "second": "foo",
+        "alphanumeric": "bar",
+    };
+
+    {
+        let first_entry = doc.entry("first".to_owned());
+        assert_eq!(first_entry.key(), "first");
+
+        let v = first_entry.or_insert_with(|| Bson::TimeStamp(27));
+        assert_eq!(v, &mut Bson::I32(1));
+    }
+
+    {
+        let fourth_entry = doc.entry("fourth".to_owned());
+        assert_eq!(fourth_entry.key(), "fourth");
+
+        let v = fourth_entry.or_insert(Bson::Null);
+        assert_eq!(v, &mut Bson::Null);
+    }
+
+    assert_eq!(
+        doc,
+        doc! {
+            "first": 1i32,
+            "second": "foo",
+            "alphanumeric": "bar",
+            "fourth": Bson::Null,
+        },
+    );
+}


### PR DESCRIPTION
Since the last time the `linked-hash-map` dependency was updated, it added an entry API to mimic that of the standard library for modifying an entry in the map in-place to get around borrow checker issues when trying to get and insert at the same time. This PR adds a thin wrapper around this functionality for the underlying map used by a `Document`.

I attempted to implement the `entries` method as well, but due to [this](https://github.com/contain-rs/linked-hash-map/pull/89) not yet being released on crates.io, it wasn't working, so I didn't include it in this PR.