### PR TITLE
add TimeStamp type to facilitate deserialization

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -595,6 +595,27 @@ impl Bson {
     }
 }
 
+/// `TimeStamp` representation in struct for serde serialization
+///
+/// Just a helper for convenience
+///
+/// ```rust,ignore
+/// #[macro_use]
+/// extern crate serde_derive;
+/// extern crate bson;
+/// use bson::TimeStamp;
+///
+/// #[derive(Serialize, Deserialize)]
+/// struct Foo {
+///     timestamp: TimeStamp,
+/// }
+/// ```
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct TimeStamp {
+    pub t: u32,
+    pub i: u32,
+}
+
 /// `DateTime` representation in struct for serde serialization
 ///
 /// Just a helper for convenience

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ extern crate linked_hash_map;
 extern crate hostname;
 extern crate hex;
 
-pub use self::bson::{Bson, Document, Array, UtcDateTime};
+pub use self::bson::{Bson, Document, Array, TimeStamp, UtcDateTime};
 pub use self::encoder::{encode_document, to_bson, Encoder, EncoderResult, EncoderError};
 pub use self::decoder::{decode_document, decode_document_utf8_lossy, from_bson, Decoder, DecoderResult, DecoderError};
 pub use self::ordered::{ValueAccessError, ValueAccessResult};

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -59,6 +59,22 @@ fn test_de_map() {
 }
 
 #[test]
+fn test_de_timestamp() {
+    use bson::TimeStamp;
+
+    #[derive(Deserialize, Eq, PartialEq, Debug)]
+    struct Foo {
+        ts: TimeStamp,
+    }
+
+    let foo: Foo = bson::from_bson(Bson::Document(doc! {
+        "ts": Bson::TimeStamp(0x0A00_0000_0C00_0000),
+    })).unwrap();
+
+    assert_eq!(foo.ts, TimeStamp { t: 12, i: 10 });
+}
+
+#[test]
 fn test_ser_datetime() {
     use chrono::{Utc, Timelike};
     use bson::UtcDateTime;


### PR DESCRIPTION
Currently, there is no good way to deserialize the BSON timestamp type. The only thing that works is deserializing into the `Bson` enum, but that doesn't provide any compile-time guarantees that the value is actually a timestamp type. Following the example of `bson::UtcDateTime`, I implemented a timestamp type that can be used when deserializing.