### PR TITLE
TimeStamp type uses incorrect endianness?

### DIFF
--- a/src/decoder/serde.rs
+++ b/src/decoder/serde.rs
@@ -592,12 +592,12 @@ impl<'de> Deserialize<'de> for TimeStamp {
 
         match Bson::deserialize(deserializer)? {
             Bson::TimeStamp(ts) => {
-                let ts = ts.to_be();
+                let ts = ts.to_le();
 
                 Ok(TimeStamp { t: ((ts as u64) >> 32) as u32,
                                i: (ts & 0xFFFF_FFFF) as u32, })
             }
-            _ => Err(D::Error::custom("expecting UtcDateTime")),
+            _ => Err(D::Error::custom("expecting TimeStamp")),
         }
     }
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -69,7 +69,7 @@ fn test_de_timestamp() {
     }
 
     let foo: Foo = bson::from_bson(Bson::Document(doc! {
-        "ts": Bson::TimeStamp(0x0A00_0000_0C00_0000),
+        "ts": Bson::TimeStamp(0x0000_000C_0000_000A),
     })).unwrap();
 
     assert_eq!(foo.ts, TimeStamp { t: 12, i: 10 });


### PR DESCRIPTION
Hello,

I have recently attempted to use the new `bson::TimeStamp` type to decode an optime returned by the `replSetGetStatus` MongoDB command.
The value that I got was different from the result of `rs.status()`.

After a bit of investigation I noticed the timestamp is converted to big endian before it is masked and shifted: https://github.com/zonyitoo/bson-rs/blob/master/src/decoder/serde.rs#L595

I am not familiar with the protocol but other clients (including the bson package in the mongodb repo) seem to use little endian encoding for the values of the timestamp:

  * Go Client: https://github.com/mongodb/mongo-go-driver/blob/master/bson/value.go#L820
  * Comment in the official MongoDB codebase: https://github.com/mongodb/mongo/blob/master/src/mongo/bson/timestamp.cpp#L51-L52

Is this indeed a bug or am I doing something wrong?