### PR TITLE
Implement TimeStamp  serde serialisation

### DIFF
--- a/src/encoder/serde.rs
+++ b/src/encoder/serde.rs
@@ -1,7 +1,7 @@
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
                  SerializeTupleStruct, SerializeTupleVariant, Serializer};
 
-use bson::{Array, Bson, Document, UtcDateTime};
+use bson::{Array, Bson, Document, UtcDateTime, TimeStamp};
 use oid::ObjectId;
 use try_from::TryFrom;
 
@@ -432,6 +432,17 @@ impl SerializeStructVariant for StructVariantSerializer {
         struct_variant.insert(self.name, var);
 
         Ok(Bson::Document(struct_variant))
+    }
+}
+
+impl Serialize for TimeStamp {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        let ts = ((self.t.to_le() as u64) << 32) | (self.i.to_le() as u64);
+        let doc = Bson::TimeStamp(ts as i64);
+        doc.serialize(serializer)
     }
 }
 

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -60,6 +60,24 @@ fn test_de_map() {
 }
 
 #[test]
+fn test_ser_timestamp() {
+    use bson::TimeStamp;
+
+    #[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
+    struct Foo {
+        ts: TimeStamp,
+    }
+
+    let foo = Foo { ts: TimeStamp { t: 12, i: 10 } };
+
+    let x = bson::to_bson(&foo).unwrap();
+    assert_eq!(x.as_document().unwrap(), &doc! { "ts": Bson::TimeStamp(0x0000_000C_0000_000A) });
+
+    let xfoo: Foo = bson::from_bson(x).unwrap();
+    assert_eq!(xfoo, foo);
+}
+
+#[test]
 fn test_de_timestamp() {
     use bson::TimeStamp;
 


### PR DESCRIPTION
The `bson::TimeStamp` type does not currently implement `serde::Serialise`.
As a result things like the example below fail to compile.
```rust
use bson::TimeStamp;

#[derive(Serialise)]
pub struct Foo {
  ts: TimeStamp,
}
```

This PR would implement `Serialise` for `bson::TimeStamp` so the above code compiles.