### PR TITLE
add wasm support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
 sudo: false
 
 script:
+    - rustup target add wasm32-unknown-unknown
     - cargo build -v
     - cargo check --target wasm32-unknown-unknown
     - cargo test -v --no-fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ sudo: false
 
 script:
     - cargo build -v
+    - cargo check --target wasm32-unknown-unknown
     - cargo test -v --no-fail-fast
     - cargo test -v --no-fail-fast --features u2i
     - cd serde-tests && cargo test -v --no-fail-fast

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ try_from = "0.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 hostname = "0.1"
+libc = "0.2"
 
 [dev-dependencies]
 assert_matches = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,12 @@ serde = "1.0"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 time = "0.1"
 linked-hash-map = "0.5"
-hostname = "0.1"
 hex = "0.3"
 md5 = "0.3"
 try_from = "0.2"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+hostname = "0.1"
 
 [dev-dependencies]
 assert_matches = "1.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,6 @@
 extern crate byteorder;
 extern crate chrono;
 extern crate hex;
-extern crate libc;
 extern crate linked_hash_map;
 extern crate rand;
 extern crate serde;
@@ -57,6 +56,8 @@ extern crate try_from;
 
 #[cfg(not(target_arch = "wasm32"))]
 extern crate hostname;
+#[cfg(not(target_arch = "wasm32"))]
+extern crate libc;
 
 pub use self::bson::{Array, Bson, Document, TimeStamp, UtcDateTime};
 pub use self::decoder::{decode_document, decode_document_utf8_lossy, from_bson, Decoder, DecoderError, DecoderResult};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,6 @@
 extern crate byteorder;
 extern crate chrono;
 extern crate hex;
-extern crate hostname;
 extern crate libc;
 extern crate linked_hash_map;
 extern crate rand;
@@ -55,6 +54,9 @@ extern crate serde_json;
 extern crate md5;
 extern crate time;
 extern crate try_from;
+
+#[cfg(not(target_arch = "wasm32"))]
+extern crate hostname;
 
 pub use self::bson::{Array, Bson, Document, TimeStamp, UtcDateTime};
 pub use self::decoder::{decode_document, decode_document_utf8_lossy, from_bson, Decoder, DecoderError, DecoderResult};


### PR DESCRIPTION
Hello!

I am using this module in a [library](https://github.com/lrlna/mongodb-schema-parser) that will be compiled to WASM. The current version doesn't quite work, as it makes system calls (`get_hostname()` and `libc::getpid()` specifically). 
You can try this yourself with `cargo build --target wasm32-unknown-unknown`.

This PR adds two replacement functions that will only be used in case of WASM, and in all other cases the current implementation will stay. The WASM-compatible functions just generate random numbers for machine id and process id; it's done similarly in the [js version of bson](https://github.com/mongodb/js-bson/blob/master/lib/objectid.js#L8).

Thank you for reviewing o/ !

