### PR TITLE
Add Decimal128 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,6 @@ try_from = "0.2"
 assert_matches = "1.2"
 serde_derive = "1.0"
 serde_bytes = "0.10"
+
+[dependencies.decimal]
+git = "https://github.com/alkis/decimal"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,9 @@ hostname = "0.1"
 hex = "0.3"
 md5 = "0.3"
 try_from = "0.2"
+decimal = "2.0.4"
 
 [dev-dependencies]
 assert_matches = "1.2"
 serde_derive = "1.0"
 serde_bytes = "0.10"
-
-[dependencies.decimal]
-git = "https://github.com/alkis/decimal"

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -156,7 +156,7 @@ impl Display for Bson {
             Bson::ObjectId(ref id) => write!(fmt, "ObjectId(\"{}\")", id),
             Bson::UtcDatetime(date_time) => write!(fmt, "Date(\"{}\")", date_time),
             Bson::Symbol(ref sym) => write!(fmt, "Symbol(\"{}\")", sym),
-            Bson::Decimal128(ref d) => write!(fmt, "{}", d),
+            Bson::Decimal128(ref d) => write!(fmt, "Decimal128({})", d),
         }
     }
 }

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -29,10 +29,10 @@ use chrono::{DateTime, Timelike, Utc};
 use hex;
 use serde_json::Value;
 
+use decimal128::Decimal128;
 use oid;
 use ordered::OrderedDocument;
 use spec::{BinarySubtype, ElementType};
-use decimal128::Decimal128;
 
 /// Possible BSON value types.
 #[derive(Clone, PartialEq)]
@@ -280,9 +280,7 @@ impl From<Value> for Bson {
             Value::String(x) => x.into(),
             Value::Bool(x) => x.into(),
             Value::Array(x) => Bson::Array(x.into_iter().map(Bson::from).collect()),
-            Value::Object(x) => {
-                Bson::from_extended_document(x.into_iter().map(|(k, v)| (k, v.into())).collect())
-            }
+            Value::Object(x) => Bson::from_extended_document(x.into_iter().map(|(k, v)| (k, v.into())).collect()),
             Value::Null => Bson::Null,
         }
     }
@@ -331,12 +329,7 @@ impl From<Bson> for Value {
                 }),
             // FIXME: Don't know what is the best way to encode Symbol type
             Bson::Symbol(v) => json!({ "$symbol": v }),
-            Bson::Decimal128(ref v) => {
-                let mut obj = json::Object::new();
-                obj.insert("$numberDecimal".to_owned(),
-                           json::Json::String(v.to_string()));
-                json::Json::Object(obj)
-            }
+            Bson::Decimal128(ref v) => json!({ "$numberDecimal": v.to_string() }),
         }
     }
 }

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -32,6 +32,7 @@ use serde_json::Value;
 use oid;
 use ordered::OrderedDocument;
 use spec::{BinarySubtype, ElementType};
+use decimal128::Decimal128;
 
 /// Possible BSON value types.
 #[derive(Clone, PartialEq)]
@@ -72,6 +73,8 @@ pub enum Bson {
     UtcDatetime(DateTime<Utc>),
     /// Symbol (Deprecated)
     Symbol(String),
+    /// [128-bit decimal floating point](https://github.com/mongodb/specifications/blob/master/source/bson-decimal128/decimal128.rst)
+    Decimal128(Decimal128),
 }
 
 /// Alias for `Vec<Bson>`.
@@ -111,6 +114,7 @@ impl Debug for Bson {
             Bson::ObjectId(ref id) => write!(f, "ObjectId({:?})", id),
             Bson::UtcDatetime(date_time) => write!(f, "UtcDatetime({:?})", date_time),
             Bson::Symbol(ref sym) => write!(f, "Symbol({:?})", sym),
+            Bson::Decimal128(ref d) => write!(f, "Decimal128({:?})", d),
         }
     }
 }
@@ -152,6 +156,7 @@ impl Display for Bson {
             Bson::ObjectId(ref id) => write!(fmt, "ObjectId(\"{}\")", id),
             Bson::UtcDatetime(date_time) => write!(fmt, "Date(\"{}\")", date_time),
             Bson::Symbol(ref sym) => write!(fmt, "Symbol(\"{}\")", sym),
+            Bson::Decimal128(ref d) => write!(fmt, "{}", d),
         }
     }
 }
@@ -326,6 +331,12 @@ impl From<Bson> for Value {
                 }),
             // FIXME: Don't know what is the best way to encode Symbol type
             Bson::Symbol(v) => json!({ "$symbol": v }),
+            Bson::Decimal128(ref v) => {
+                let mut obj = json::Object::new();
+                obj.insert("$numberDecimal".to_owned(),
+                           json::Json::String(v.to_string()));
+                json::Json::Object(obj)
+            }
         }
     }
 }
@@ -350,6 +361,7 @@ impl Bson {
             Bson::ObjectId(..) => ElementType::ObjectId,
             Bson::UtcDatetime(..) => ElementType::UtcDatetime,
             Bson::Symbol(..) => ElementType::Symbol,
+            Bson::Decimal128(..) => ElementType::Decimal128Bit,
         }
     }
 
@@ -429,6 +441,11 @@ impl Bson {
                     "$symbol": v.to_owned(),
                 }
             }
+            Bson::Decimal128(ref v) => {
+                doc! {
+                    "$numberDecimal" => (v.to_string())
+                }
+            }
             _ => panic!("Attempted conversion of invalid data type: {}", self),
         }
     }
@@ -463,6 +480,8 @@ impl Bson {
                 return Bson::UtcDatetime(Utc.timestamp(long / 1000, ((long % 1000) * 1000000) as u32));
             } else if let Ok(sym) = values.get_str("$symbol") {
                 return Bson::Symbol(sym.to_owned());
+            } else if let Ok(dec) = values.get_str("$numberDecimal") {
+                return Bson::Decimal128(dec.parse::<Decimal128>().unwrap());
             }
         }
 

--- a/src/decimal128.rs
+++ b/src/decimal128.rs
@@ -1,0 +1,140 @@
+//! `Decimal128` data type representation
+//!
+//! Specification is https://github.com/mongodb/specifications/blob/master/source/bson-decimal128/decimal128.rst
+
+use std::fmt;
+use std::str::FromStr;
+
+use decimal::d128;
+
+/// Decimal128 type
+#[derive(Clone, PartialEq, PartialOrd)]
+pub struct Decimal128 {
+    inner: d128,
+}
+
+impl Decimal128 {
+    /// Construct a `Decimal128` from string.
+    ///
+    /// For example:
+    ///
+    /// * `NaN`
+    /// * `Infinity` or `Inf`
+    /// * `1.0`, `+37.0`, `0.73e-7`, `.5`
+    pub fn from_str(s: &str) -> Decimal128 {
+        Decimal128 { inner: s.parse::<d128>().expect("Invalid Decimal128 string") }
+    }
+
+    /// Construct a `Decimal128` from a `i32` number
+    pub fn from_i32(d: i32) -> Decimal128 {
+        Decimal128 { inner: From::from(d) }
+    }
+
+    /// Construct a `Decimal128` from a `u32` number
+    pub fn from_u32(d: u32) -> Decimal128 {
+        Decimal128 { inner: From::from(d) }
+    }
+
+    /// Get a `0`
+    pub fn zero() -> Decimal128 {
+        Decimal128 { inner: d128::zero() }
+    }
+
+    #[doc(hidden)]
+    pub unsafe fn from_raw_bytes_le(mut raw: [u8; 16]) -> Decimal128 {
+        if cfg!(target_endian = "big") {
+            raw.reverse();
+        }
+
+        Decimal128 { inner: d128::from_raw_bytes(raw) }
+    }
+
+    #[doc(hidden)]
+    pub fn to_raw_bytes_le(&self) -> [u8; 16] {
+        let mut buf = self.inner.to_raw_bytes();
+        if cfg!(target_endian = "big") {
+            buf.reverse();
+        }
+        buf
+    }
+
+    /// Check if value is `NaN`
+    pub fn is_nan(&self) -> bool {
+        self.inner.is_nan()
+    }
+
+    /// Check if value is 0
+    pub fn is_zero(&self) -> bool {
+        self.inner.is_zero()
+    }
+}
+
+impl fmt::Debug for Decimal128 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Decimal(\"{:?}\")", self.inner)
+    }
+}
+
+impl fmt::Display for Decimal128 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl fmt::LowerHex for Decimal128 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        <d128 as fmt::LowerHex>::fmt(&self.inner, f)
+    }
+}
+
+impl fmt::LowerExp for Decimal128 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        <d128 as fmt::LowerExp>::fmt(&self.inner, f)
+    }
+}
+
+impl FromStr for Decimal128 {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Decimal128, ()> {
+        Ok(Decimal128::from_str(s))
+    }
+}
+
+impl Into<d128> for Decimal128 {
+    fn into(self) -> d128 {
+        self.inner
+    }
+}
+
+impl From<d128> for Decimal128 {
+    fn from(d: d128) -> Decimal128 {
+        Decimal128 { inner: d }
+    }
+}
+
+impl Default for Decimal128 {
+    fn default() -> Decimal128 {
+        Decimal128::zero()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_decimal128_string() {
+        assert!(Decimal128::from_str("0").is_zero());
+        assert!(!Decimal128::from_str("12").is_nan());
+        assert!(!Decimal128::from_str("-76").is_nan());
+        assert!(!Decimal128::from_str("12.70").is_nan());
+        assert!(!Decimal128::from_str("+0.003").is_nan());
+        assert!(!Decimal128::from_str("017.").is_nan());
+        assert!(!Decimal128::from_str(".5").is_nan());
+        assert!(!Decimal128::from_str("4E+9").is_nan());
+        assert!(!Decimal128::from_str("0.73e-7").is_nan());
+        assert!(!Decimal128::from_str("Inf").is_nan());
+        assert!(!Decimal128::from_str("-infinity").is_nan());
+        assert!(Decimal128::from_str("NaN").is_nan());
+    }
+}

--- a/src/decimal128.rs
+++ b/src/decimal128.rs
@@ -8,7 +8,7 @@ use decimal::d128;
 /// Decimal128 type
 #[derive(Clone, PartialEq, PartialOrd)]
 pub struct Decimal128 {
-    d128: d128,
+    inner: d128,
 }
 
 impl Decimal128 {
@@ -26,7 +26,7 @@ impl Decimal128 {
     /// let dec128 = Decimal128::from_str("1.05E+3");
     /// ```
     pub fn from_str(s: &str) -> Decimal128 {
-        Decimal128 { d128: s.parse::<d128>().expect("Invalid Decimal128 string"), }
+        Decimal128 { inner: s.parse::<d128>().expect("Invalid Decimal128 string"), }
     }
 
     /// Construct a `Decimal128` from a `i32` number.
@@ -38,7 +38,7 @@ impl Decimal128 {
     /// let dec128 = Decimal128::from_i32(num);
     /// ```
     pub fn from_i32(d: i32) -> Decimal128 {
-        Decimal128 { d128: From::from(d) }
+        Decimal128 { inner: From::from(d) }
     }
 
     /// Construct a `Decimal128` from a `u32` number.
@@ -50,7 +50,35 @@ impl Decimal128 {
     /// let dec128 = Decimal128::from_u32(num);
     /// ```
     pub fn from_u32(d: u32) -> Decimal128 {
-        Decimal128 { d128: From::from(d) }
+        Decimal128 { inner: From::from(d) }
+    }
+
+    /// Construct a `Decimal128` from a `i32` number.
+    ///
+    /// ```rust
+    /// use bson::decimal128::Decimal128;
+    ///
+    /// let num: i32 = 23;
+    /// let dec128 = Decimal128::from_i32(num);
+    /// let int = dec128.into_i32();
+    /// assert_eq!(int, num);
+    /// ```
+    pub fn into_i32(&self) -> i32 {
+        Into::into(self.inner)
+    }
+
+    /// Construct a `Decimal128` from a `i32` number.
+    ///
+    /// ```rust
+    /// use bson::decimal128::Decimal128;
+    ///
+    /// let num: u32 = 23;
+    /// let dec128 = Decimal128::from_u32(num);
+    /// let int = dec128.into_u32();
+    /// assert_eq!(int, num);
+    /// ```
+    pub fn into_u32(&self) -> u32 {
+        Into::into(self.inner)
     }
 
     /// Create a new Decimal128 as `0`.
@@ -61,7 +89,7 @@ impl Decimal128 {
     /// let dec128 = Decimal128::zero();
     /// ```
     pub fn zero() -> Decimal128 {
-        Decimal128 { d128: d128::zero() }
+        Decimal128 { inner: d128::zero() }
     }
 
     #[doc(hidden)]
@@ -70,12 +98,12 @@ impl Decimal128 {
             raw.reverse();
         }
 
-        Decimal128 { d128: d128::from_raw_bytes(raw), }
+        Decimal128 { inner: d128::from_raw_bytes(raw), }
     }
 
     #[doc(hidden)]
     pub fn to_raw_bytes_le(&self) -> [u8; 16] {
-        let mut buf = self.d128.to_raw_bytes();
+        let mut buf = self.inner.to_raw_bytes();
         if cfg!(target_endian = "big") {
             buf.reverse();
         }
@@ -92,7 +120,7 @@ impl Decimal128 {
     /// assert!(!dec128.is_nan());
     /// ```
     pub fn is_nan(&self) -> bool {
-        self.d128.is_nan()
+        self.inner.is_nan()
     }
 
     /// Check if value is 0
@@ -105,31 +133,31 @@ impl Decimal128 {
     /// assert!(dec128.is_zero());
     /// ```
     pub fn is_zero(&self) -> bool {
-        self.d128.is_zero()
+        self.inner.is_zero()
     }
 }
 
 impl fmt::Debug for Decimal128 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Decimal(\"{:?}\")", self.d128)
+        write!(f, "Decimal(\"{:?}\")", self.inner)
     }
 }
 
 impl fmt::Display for Decimal128 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.d128)
+        write!(f, "{}", self.inner)
     }
 }
 
 impl fmt::LowerHex for Decimal128 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        <d128 as fmt::LowerHex>::fmt(&self.d128, f)
+        <d128 as fmt::LowerHex>::fmt(&self.inner, f)
     }
 }
 
 impl fmt::LowerExp for Decimal128 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        <d128 as fmt::LowerExp>::fmt(&self.d128, f)
+        <d128 as fmt::LowerExp>::fmt(&self.inner, f)
     }
 }
 
@@ -142,13 +170,13 @@ impl FromStr for Decimal128 {
 
 impl Into<d128> for Decimal128 {
     fn into(self) -> d128 {
-        self.d128
+        self.inner
     }
 }
 
 impl From<d128> for Decimal128 {
     fn from(d: d128) -> Decimal128 {
-        Decimal128 { d128: d }
+        Decimal128 { inner: d }
     }
 }
 
@@ -163,7 +191,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_decimal128_string() {
+    fn decimal128_string() {
         assert!(Decimal128::from_str("0").is_zero());
         assert!(!Decimal128::from_str("12").is_nan());
         assert!(!Decimal128::from_str("-76").is_nan());
@@ -176,5 +204,49 @@ mod test {
         assert!(!Decimal128::from_str("Inf").is_nan());
         assert!(!Decimal128::from_str("-infinity").is_nan());
         assert!(Decimal128::from_str("NaN").is_nan());
+    }
+
+    #[test]
+    fn decimal128_i32() {
+        let num: i32 = 89;
+        let dec128 = Decimal128::from_i32(num);
+
+        assert!(!dec128.is_nan());
+        assert!(!dec128.is_zero());
+        assert_eq!(dec128.into_i32(), num);
+    }
+
+    #[test]
+    fn decimal128_u32() {
+        let num: u32 = 89;
+        let dec128 = Decimal128::from_u32(num);
+
+        assert!(!dec128.is_nan());
+        assert!(!dec128.is_zero());
+        assert_eq!(dec128.into_u32(), num);
+    }
+
+    #[test]
+    fn decimal128_0() {
+        let dec128 = Decimal128::zero();
+        assert!(dec128.is_zero());
+    }
+
+    #[test]
+    fn decimal128_is_zero() {
+        let dec128 = Decimal128::from_i32(234);
+        assert!(!dec128.is_zero());
+
+        let dec128_0 = Decimal128::from_i32(0);
+        assert!(dec128_0.is_zero());
+    }
+
+    #[test]
+    fn decimal128_is_nan() {
+        let dec128 = Decimal128::from_str("NaN");
+        assert!(dec128.is_nan());
+
+        let dec128 = Decimal128::from_i32(234);
+        assert!(!dec128.is_nan());
     }
 }

--- a/src/decimal128.rs
+++ b/src/decimal128.rs
@@ -1,6 +1,4 @@
-//! `Decimal128` data type representation
-//!
-//! Specification is https://github.com/mongodb/specifications/blob/master/source/bson-decimal128/decimal128.rst
+//! [BSON Decimal128](https://github.com/mongodb/specifications/blob/master/source/bson-decimal128/decimal128.rst) data type representation
 
 use std::fmt;
 use std::str::FromStr;
@@ -10,7 +8,7 @@ use decimal::d128;
 /// Decimal128 type
 #[derive(Clone, PartialEq, PartialOrd)]
 pub struct Decimal128 {
-    inner: d128,
+    d128: d128,
 }
 
 impl Decimal128 {
@@ -21,23 +19,49 @@ impl Decimal128 {
     /// * `NaN`
     /// * `Infinity` or `Inf`
     /// * `1.0`, `+37.0`, `0.73e-7`, `.5`
+    ///
+    /// ```rust
+    /// use bson::decimal128::Decimal128;
+    ///
+    /// let dec128 = Decimal128::from_str("1.05E+3");
+    /// ```
     pub fn from_str(s: &str) -> Decimal128 {
-        Decimal128 { inner: s.parse::<d128>().expect("Invalid Decimal128 string") }
+        Decimal128 { d128: s.parse::<d128>().expect("Invalid Decimal128 string"), }
     }
 
-    /// Construct a `Decimal128` from a `i32` number
+    /// Construct a `Decimal128` from a `i32` number.
+    ///
+    /// ```rust
+    /// use bson::decimal128::Decimal128;
+    ///
+    /// let num: i32 = 23;
+    /// let dec128 = Decimal128::from_i32(num);
+    /// ```
     pub fn from_i32(d: i32) -> Decimal128 {
-        Decimal128 { inner: From::from(d) }
+        Decimal128 { d128: From::from(d) }
     }
 
-    /// Construct a `Decimal128` from a `u32` number
+    /// Construct a `Decimal128` from a `u32` number.
+    ///
+    /// ```rust
+    /// use bson::decimal128::Decimal128;
+    ///
+    /// let num: u32 = 78;
+    /// let dec128 = Decimal128::from_u32(num);
+    /// ```
     pub fn from_u32(d: u32) -> Decimal128 {
-        Decimal128 { inner: From::from(d) }
+        Decimal128 { d128: From::from(d) }
     }
 
-    /// Get a `0`
+    /// Create a new Decimal128 as `0`.
+    ///
+    /// ```rust
+    /// use bson::decimal128::Decimal128;
+    ///
+    /// let dec128 = Decimal128::zero();
+    /// ```
     pub fn zero() -> Decimal128 {
-        Decimal128 { inner: d128::zero() }
+        Decimal128 { d128: d128::zero() }
     }
 
     #[doc(hidden)]
@@ -46,12 +70,12 @@ impl Decimal128 {
             raw.reverse();
         }
 
-        Decimal128 { inner: d128::from_raw_bytes(raw) }
+        Decimal128 { d128: d128::from_raw_bytes(raw), }
     }
 
     #[doc(hidden)]
     pub fn to_raw_bytes_le(&self) -> [u8; 16] {
-        let mut buf = self.inner.to_raw_bytes();
+        let mut buf = self.d128.to_raw_bytes();
         if cfg!(target_endian = "big") {
             buf.reverse();
         }
@@ -59,37 +83,53 @@ impl Decimal128 {
     }
 
     /// Check if value is `NaN`
+    ///
+    /// ```rust
+    /// use bson::decimal128::Decimal128;
+    ///
+    /// let num: u32 = 78;
+    /// let dec128 = Decimal128::from_u32(num);
+    /// assert!(!dec128.is_nan());
+    /// ```
     pub fn is_nan(&self) -> bool {
-        self.inner.is_nan()
+        self.d128.is_nan()
     }
 
     /// Check if value is 0
+    ///
+    /// ```rust
+    /// use bson::decimal128::Decimal128;
+    ///
+    /// let num: u32 = 0;
+    /// let dec128 = Decimal128::from_u32(num);
+    /// assert!(dec128.is_zero());
+    /// ```
     pub fn is_zero(&self) -> bool {
-        self.inner.is_zero()
+        self.d128.is_zero()
     }
 }
 
 impl fmt::Debug for Decimal128 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Decimal(\"{:?}\")", self.inner)
+        write!(f, "Decimal(\"{:?}\")", self.d128)
     }
 }
 
 impl fmt::Display for Decimal128 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.inner)
+        write!(f, "{}", self.d128)
     }
 }
 
 impl fmt::LowerHex for Decimal128 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        <d128 as fmt::LowerHex>::fmt(&self.inner, f)
+        <d128 as fmt::LowerHex>::fmt(&self.d128, f)
     }
 }
 
 impl fmt::LowerExp for Decimal128 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        <d128 as fmt::LowerExp>::fmt(&self.inner, f)
+        <d128 as fmt::LowerExp>::fmt(&self.d128, f)
     }
 }
 
@@ -102,13 +142,13 @@ impl FromStr for Decimal128 {
 
 impl Into<d128> for Decimal128 {
     fn into(self) -> d128 {
-        self.inner
+        self.d128
     }
 }
 
 impl From<d128> for Decimal128 {
     fn from(d: d128) -> Decimal128 {
-        Decimal128 { inner: d }
+        Decimal128 { d128: d }
     }
 }
 

--- a/src/encoder/serde.rs
+++ b/src/encoder/serde.rs
@@ -1,7 +1,10 @@
-use serde::ser::{Serialize, SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
-                 SerializeTupleStruct, SerializeTupleVariant, Serializer};
+use serde::ser::{
+    Serialize, SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
+    SerializeTupleStruct, SerializeTupleVariant, Serializer,
+};
 
-use bson::{Array, Bson, Document, UtcDateTime, TimeStamp};
+use bson::{Array, Bson, Document, TimeStamp, UtcDateTime};
+use decimal128::Decimal128;
 use oid::ObjectId;
 use try_from::TryFrom;
 
@@ -258,7 +261,7 @@ impl Serializer for Encoder {
 
     #[inline]
     fn serialize_struct(self, _name: &'static str, _len: usize) -> EncoderResult<Self::SerializeStruct> {
-        Ok(StructSerializer { inner: Document::new(), })
+        Ok(StructSerializer { inner: Document::new() })
     }
 
     #[inline]
@@ -432,6 +435,16 @@ impl Serialize for TimeStamp {
     {
         let ts = ((self.t.to_le() as u64) << 32) | (self.i.to_le() as u64);
         let doc = Bson::TimeStamp(ts as i64);
+        doc.serialize(serializer)
+    }
+}
+
+impl Serialize for Decimal128 {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        let doc = Bson::Decimal128(self.clone());
         doc.serialize(serializer)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,11 +55,13 @@ extern crate serde_json;
 extern crate md5;
 extern crate time;
 extern crate try_from;
+extern crate decimal;
 
 pub use self::bson::{Array, Bson, Document, TimeStamp, UtcDateTime};
 pub use self::decoder::{decode_document, decode_document_utf8_lossy, from_bson, Decoder, DecoderError, DecoderResult};
 pub use self::encoder::{encode_document, to_bson, Encoder, EncoderError, EncoderResult};
 pub use self::ordered::{ValueAccessError, ValueAccessResult};
+pub use self::decimal128::Decimal128;
 
 #[macro_use]
 pub mod macros;
@@ -70,3 +72,4 @@ mod encoder;
 pub mod oid;
 pub mod ordered;
 pub mod spec;
+pub mod decimal128;

--- a/src/ordered.rs
+++ b/src/ordered.rs
@@ -12,6 +12,7 @@ use linked_hash_map::{self, LinkedHashMap};
 use serde::de::{self, MapAccess, Visitor};
 
 use bson::{Array, Bson, Document};
+use decimal128::Decimal128;
 use oid::ObjectId;
 use spec::BinarySubtype;
 
@@ -206,6 +207,15 @@ impl OrderedDocument {
         }
     }
 
+    /// Get Decimal128 value for key, if it exists.
+    pub fn get_decimal128(&self, key: &str) -> ValueAccessResult<&Decimal128> {
+        match self.get(key) {
+            Some(&Bson::Decimal128(ref v)) => Ok(v),
+            Some(_) => Err(ValueAccessError::UnexpectedType),
+            None => Err(ValueAccessError::NotPresent),
+        }
+    }
+
     /// Get a string slice this key if it exists and has the correct type.
     pub fn get_str(&self, key: &str) -> ValueAccessResult<&str> {
         match self.get(key) {
@@ -391,7 +401,7 @@ pub struct OrderedDocumentVisitor {
 
 impl OrderedDocumentVisitor {
     pub fn new() -> OrderedDocumentVisitor {
-        OrderedDocumentVisitor { marker: PhantomData, }
+        OrderedDocumentVisitor { marker: PhantomData }
     }
 }
 

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -19,7 +19,7 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-//! Constants derived from the [BSON Specification Version 1.0](http://bsonspec.org/spec.html).
+//! Constants derived from the [BSON Specification Version 1.1](http://bsonspec.org/spec.html).
 
 use std::convert::From;
 
@@ -41,6 +41,7 @@ pub const ELEMENT_TYPE_JAVASCRIPT_CODE_WITH_SCOPE: u8 = 0x0F;
 pub const ELEMENT_TYPE_32BIT_INTEGER: u8 = 0x10;
 pub const ELEMENT_TYPE_TIMESTAMP: u8 = 0x11;
 pub const ELEMENT_TYPE_64BIT_INTEGER: u8 = 0x12;
+pub const ELEMENT_TYPE_128BIT_DECIMAL: u8 = 0x13;
 pub const ELEMENT_TYPE_MINKEY: u8 = 0xFF;
 pub const ELEMENT_TYPE_MAXKEY: u8 = 0x7F;
 
@@ -55,32 +56,50 @@ pub const BINARY_SUBTYPE_MD5: u8 = 0x05;
 ///
 /// Not all element types are representable by the `Bson` type.
 #[repr(u8)]
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum ElementType {
+    /// 64-bit binary floating point
     FloatingPoint = ELEMENT_TYPE_FLOATING_POINT,
+    /// UTF-8 string
     Utf8String = ELEMENT_TYPE_UTF8_STRING,
+    /// Embedded document
     EmbeddedDocument = ELEMENT_TYPE_EMBEDDED_DOCUMENT,
+    /// Array
     Array = ELEMENT_TYPE_ARRAY,
+    /// Binary data
     Binary = ELEMENT_TYPE_BINARY,
-    /// Deprecated.
+    /// Deprecated. Undefined (value)
     Undefined = ELEMENT_TYPE_UNDEFINED,
+    /// [ObjectId](http://dochub.mongodb.org/core/objectids)
     ObjectId = ELEMENT_TYPE_OBJECT_ID,
+    /// Boolean value
     Boolean = ELEMENT_TYPE_BOOLEAN,
+    /// UTC datetime
     UtcDatetime = ELEMENT_TYPE_UTC_DATETIME,
+    /// Null value
     NullValue = ELEMENT_TYPE_NULL_VALUE,
+    /// Regular expression - The first cstring is the regex pattern, the second is the regex options string.
+    /// Options are identified by characters, which must be stored in alphabetical order.
+    /// Valid options are 'i' for case insensitive matching, 'm' for multiline matching, 'x' for verbose mode,
+    /// 'l' to make \w, \W, etc. locale dependent, 's' for dotall mode ('.' matches everything), and 'u' to
+    /// make \w, \W, etc. match unicode.
     RegularExpression = ELEMENT_TYPE_REGULAR_EXPRESSION,
     /// Deprecated.
     DbPointer = ELEMENT_TYPE_DBPOINTER,
+    /// JavaScript code
     JavaScriptCode = ELEMENT_TYPE_JAVASCRIPT_CODE,
     /// Deprecated.
     Symbol = ELEMENT_TYPE_SYMBOL,
+    /// JavaScript code w/ scope
     JavaScriptCodeWithScope = ELEMENT_TYPE_JAVASCRIPT_CODE_WITH_SCOPE,
+    /// 32-bit integer
     Integer32Bit = ELEMENT_TYPE_32BIT_INTEGER,
+    /// Timestamp
     TimeStamp = ELEMENT_TYPE_TIMESTAMP,
+    /// 64-bit integer
     Integer64Bit = ELEMENT_TYPE_64BIT_INTEGER,
-
-    MaxKey = ELEMENT_TYPE_MAXKEY,
-    MinKey = ELEMENT_TYPE_MINKEY,
+    /// [128-bit decimal floating point](https://github.com/mongodb/specifications/blob/master/source/bson-decimal128/decimal128.rst)
+    Decimal128Bit           = ELEMENT_TYPE_128BIT_DECIMAL,
 }
 
 impl ElementType {
@@ -107,6 +126,7 @@ impl ElementType {
                  ELEMENT_TYPE_32BIT_INTEGER => Integer32Bit,
                  ELEMENT_TYPE_TIMESTAMP => TimeStamp,
                  ELEMENT_TYPE_64BIT_INTEGER => Integer64Bit,
+                 ELEMENT_TYPE_128BIT_DECIMAL => Decimal128Bit,
                  ELEMENT_TYPE_MAXKEY => MaxKey,
                  ELEMENT_TYPE_MINKEY => MinKey,
                  _ => return None,

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -99,7 +99,9 @@ pub enum ElementType {
     /// 64-bit integer
     Integer64Bit = ELEMENT_TYPE_64BIT_INTEGER,
     /// [128-bit decimal floating point](https://github.com/mongodb/specifications/blob/master/source/bson-decimal128/decimal128.rst)
-    Decimal128Bit           = ELEMENT_TYPE_128BIT_DECIMAL,
+    Decimal128Bit = ELEMENT_TYPE_128BIT_DECIMAL,
+    MaxKey = ELEMENT_TYPE_MAXKEY,
+    MinKey = ELEMENT_TYPE_MINKEY,
 }
 
 impl ElementType {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,5 +5,6 @@ extern crate bson;
 extern crate byteorder;
 extern crate chrono;
 extern crate hex;
+extern crate decimal;
 
 mod modules;

--- a/tests/modules/ordered.rs
+++ b/tests/modules/ordered.rs
@@ -1,7 +1,8 @@
-use bson::{Bson, Document};
-use bson::ValueAccessError;
+use bson::decimal128::Decimal128;
 use bson::oid::ObjectId;
 use bson::spec::BinarySubtype;
+use bson::ValueAccessError;
+use bson::{Bson, Document};
 use chrono::Utc;
 
 #[test]
@@ -11,9 +12,7 @@ fn ordered_insert() {
     doc.insert("second".to_owned(), Bson::String("foo".to_owned()));
     doc.insert("alphanumeric".to_owned(), Bson::String("bar".to_owned()));
 
-    let expected_keys = vec!["first".to_owned(),
-                             "second".to_owned(),
-                             "alphanumeric".to_owned()];
+    let expected_keys = vec!["first".to_owned(), "second".to_owned(), "alphanumeric".to_owned()];
 
     let keys: Vec<_> = doc.iter().map(|(key, _)| key.to_owned()).collect();
     assert_eq!(expected_keys, keys);
@@ -26,9 +25,7 @@ fn ordered_insert_shorthand() {
     doc.insert("second", "foo");
     doc.insert("alphanumeric", "bar".to_owned());
 
-    let expected_keys = vec!["first".to_owned(),
-                             "second".to_owned(),
-                             "alphanumeric".to_owned()];
+    let expected_keys = vec!["first".to_owned(), "second".to_owned(), "alphanumeric".to_owned()];
 
     let keys: Vec<_> = doc.iter().map(|(key, _)| key.to_owned()).collect();
     assert_eq!(expected_keys, keys);
@@ -53,14 +50,12 @@ fn test_getters() {
 
     assert_eq!(None, doc.get("nonsense"));
     assert_eq!(Err(ValueAccessError::NotPresent), doc.get_str("nonsense"));
-    assert_eq!(Err(ValueAccessError::UnexpectedType),
-               doc.get_str("floating_point"));
+    assert_eq!(Err(ValueAccessError::UnexpectedType), doc.get_str("floating_point"));
 
     assert_eq!(Some(&Bson::FloatingPoint(10.0)), doc.get("floating_point"));
     assert_eq!(Ok(10.0), doc.get_f64("floating_point"));
 
-    assert_eq!(Some(&Bson::String("a value".to_string())),
-               doc.get("string"));
+    assert_eq!(Some(&Bson::String("a value".to_string())), doc.get("string"));
     assert_eq!(Ok("a value"), doc.get_str("string"));
 
     let array = vec![Bson::I32(10), Bson::I32(20), Bson::I32(30)];
@@ -89,8 +84,15 @@ fn test_getters() {
     assert_eq!(Some(&Bson::TimeStamp(100)), doc.get("timestamp"));
     assert_eq!(Ok(100i64), doc.get_time_stamp("timestamp"));
 
-    assert_eq!(Some(&Bson::UtcDatetime(datetime.clone())),
-               doc.get("datetime"));
+    assert_eq!(Some(&Bson::UtcDatetime(datetime.clone())), doc.get("datetime"));
+    assert_eq!(Ok(&datetime), doc.get_utc_datetime("datetime"));
+
+    let dec = Decimal128::from_str("968E+1");
+    doc.insert("decimal128".to_string(), Bson::Decimal128(dec.clone()));
+    assert_eq!(Some(&Bson::Decimal128(dec.clone())), doc.get("decimal128"));
+    assert_eq!(Ok(&dec), doc.get_decimal128("decimal128"));
+
+    assert_eq!(Some(&Bson::UtcDatetime(datetime.clone())), doc.get("datetime"));
     assert_eq!(Ok(&datetime), doc.get_utc_datetime("datetime"));
 
     let object_id = ObjectId::new().unwrap();

--- a/tests/modules/ser.rs
+++ b/tests/modules/ser.rs
@@ -1,7 +1,8 @@
-use bson::{from_bson, to_bson, Bson, EncoderError, EncoderResult};
+use bson::decimal128::Decimal128;
 use bson::oid::ObjectId;
+use bson::{from_bson, to_bson, Bson, EncoderError, EncoderResult};
 use std::collections::BTreeMap;
-use std::{u8, u16, u32, u64};
+use std::{u16, u32, u64, u8};
 
 #[test]
 fn floating_point() {
@@ -51,6 +52,17 @@ fn int32() {
     assert_eq!(i, 101);
 
     let deser: Bson = to_bson(&i).unwrap();
+    assert_eq!(deser, obj);
+}
+
+#[test]
+fn dec128() {
+    let d128 = Decimal128::from_str("1.05E+3");
+    let obj = Bson::Decimal128(d128.clone());
+    let ser: Decimal128 = from_bson(obj.clone()).unwrap();
+    assert_eq!(ser, d128);
+
+    let deser: Bson = to_bson(&ser).unwrap();
     assert_eq!(deser, obj);
 }
 


### PR DESCRIPTION
Hello!

I wanted to pull in the work @zonyitoo has done in the past to allow support for [Decimal128](https://github.com/mongodb/specifications/tree/master/source/bson-decimal128). 

This PR:
- [x] rebases that work over to master, 
- [x] includes a few more tests
- [x] a serialization + deserialization for BSON Decimal128 type
- [x] a few docs
- [x] and two more methods for decimal128 -> i32 and u32 conversions. 

@saghm and @kyeah if either of you have time for a review, I would really appreciate it. 

Thank you for your time!