### PR TITLE
Turn off default features of decimal and enable decimal128 in the docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,12 @@ time = "0.1"
 linked-hash-map = "0.5"
 hex = "0.3"
 md5 = "0.6"
-decimal = { version = "2.0.4", optional = true }
+decimal = { version = "2.0.4", default_features = false, optional = true }
 
 [dev-dependencies]
 assert_matches = "1.2"
 serde_derive = "1.0"
 serde_bytes = "0.11"
+
+[package.metadata.docs.rs]
+features = ["decimal128"]


### PR DESCRIPTION
I mainly did this PR for the case that #125 doesn't end up being merged. It reduces the number of dependencies a little and enables decimal128 on docs.rs. That second part is also useful if #125 is not being merged.