### PR TITLE
Add more Bson From<> implementations for better ergonomics.

### DIFF
--- a/src/bson.rs
+++ b/src/bson.rs
@@ -177,7 +177,7 @@ impl From<f64> for Bson {
     }
 }
 
-impl<'a> From<&'a str> for Bson {
+impl From<&str> for Bson {
     fn from(s: &str) -> Bson {
         Bson::String(s.to_owned())
     }
@@ -186,18 +186,6 @@ impl<'a> From<&'a str> for Bson {
 impl From<String> for Bson {
     fn from(a: String) -> Bson {
         Bson::String(a)
-    }
-}
-
-impl<'a> From<&'a String> for Bson {
-    fn from(a: &'a String) -> Bson {
-        Bson::String(a.to_owned())
-    }
-}
-
-impl From<Array> for Bson {
-    fn from(a: Array) -> Bson {
-        Bson::Array(a)
     }
 }
 
@@ -228,6 +216,49 @@ impl From<(String, Document)> for Bson {
 impl From<(BinarySubtype, Vec<u8>)> for Bson {
     fn from((ty, data): (BinarySubtype, Vec<u8>)) -> Bson {
         Bson::Binary(ty, data)
+    }
+}
+
+impl<T> From<&T> for Bson
+where
+    T: Clone + Into<Bson>
+{
+    fn from(t: &T) -> Bson {
+        t.clone().into()
+    }
+}
+
+impl<T> From<Vec<T>> for Bson
+where
+    T: Into<Bson>
+{
+    fn from(v: Vec<T>) -> Bson {
+        Bson::Array(v.into_iter().map(|val| val.into()).collect())
+    }
+}
+
+impl<T> From<&[T]> for Bson
+where
+    T: Clone + Into<Bson>
+{
+    fn from(s: &[T]) -> Bson {
+        Bson::Array(s.into_iter().cloned().map(|val| val.into()).collect())
+    }
+}
+
+impl<T: Into<Bson>> ::std::iter::FromIterator<T> for Bson {
+    /// # Examples
+    ///
+    /// ```
+    /// use std::iter::FromIterator;
+    /// use bson::Bson;
+    ///
+    /// let x: Bson = Bson::from_iter(vec!["lorem", "ipsum", "dolor"]);
+    /// // or
+    /// let x: Bson = vec!["lorem", "ipsum", "dolor"].into_iter().collect();
+    /// ```
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Bson::Array(iter.into_iter().map(Into::into).collect())
     }
 }
 
@@ -719,8 +750,7 @@ impl Bson {
 /// Just a helper for convenience
 ///
 /// ```rust,ignore
-/// #[macro_use]
-/// extern crate serde_derive;
+/// use serde::{Serialize, Deserialize};
 /// extern crate bson;
 /// use bson::TimeStamp;
 ///

--- a/tests/modules/bson.rs
+++ b/tests/modules/bson.rs
@@ -1,11 +1,12 @@
 extern crate serde_json;
 
-use self::serde_json::Value;
-use bson::{Bson, Document};
+use self::serde_json::{Value, json};
+use bson::{Bson, Document, oid::ObjectId, spec::BinarySubtype};
 
 #[test]
 fn to_json() {
     let mut doc = Document::new();
+    doc.insert("_id", Bson::ObjectId(ObjectId::with_bytes(*b"abcdefghijkl")));
     doc.insert("first", Bson::I32(1));
     doc.insert("second", Bson::String("foo".to_owned()));
     doc.insert("alphanumeric", Bson::String("bar".to_owned()));
@@ -13,6 +14,12 @@ fn to_json() {
 
     assert!(data.is_object());
     let obj = data.as_object().unwrap();
+
+    let id = obj.get("_id").unwrap();
+    assert!(id.is_object());
+    let id_val = id.get("$oid").unwrap();
+    assert!(id_val.is_string());
+    assert_eq!(id_val, "6162636465666768696a6b6c");
 
     let first = obj.get("first").unwrap();
     assert!(first.is_number());
@@ -38,4 +45,35 @@ fn document_default() {
     let doc1 = Document::default();
     assert_eq!(doc1.keys().count(), 0);
     assert_eq!(doc1, Document::new());
+}
+
+#[test]
+fn from_impls() {
+    assert_eq!(Bson::from(1.5f32), Bson::FloatingPoint(1.5));
+    assert_eq!(Bson::from(2.25f64), Bson::FloatingPoint(2.25));
+    assert_eq!(Bson::from("data"), Bson::String(String::from("data")));
+    assert_eq!(Bson::from(String::from("data")), Bson::String(String::from("data")));
+    assert_eq!(Bson::from(doc!{}), Bson::Document(Document::new()));
+    assert_eq!(Bson::from(false), Bson::Boolean(false));
+    assert_eq!(Bson::from((String::from("\\s+$"), String::from("i"))), Bson::RegExp(String::from("\\s+$"), String::from("i")));
+    assert_eq!(Bson::from((String::from("alert(\"hi\");"), doc!{})), Bson::JavaScriptCodeWithScope(String::from("alert(\"hi\");"), doc!{}));
+    //
+    assert_eq!(Bson::from((BinarySubtype::Generic, vec![1, 2, 3])), Bson::Binary(BinarySubtype::Generic, vec![1, 2, 3]));
+    assert_eq!(Bson::from(-48i32), Bson::I32(-48));
+    assert_eq!(Bson::from(-96i64), Bson::I64(-96));
+    assert_eq!(Bson::from(152u32), Bson::I32(152));
+    assert_eq!(Bson::from(4096u64), Bson::I64(4096));
+
+    let oid = ObjectId::new().unwrap();
+    assert_eq!(Bson::from(b"abcdefghijkl"), Bson::ObjectId(ObjectId::with_bytes(*b"abcdefghijkl")));
+    assert_eq!(Bson::from(oid.clone()), Bson::ObjectId(oid.clone()));
+    assert_eq!(Bson::from(vec![1, 2, 3]), Bson::Array(vec![Bson::I32(1), Bson::I32(2), Bson::I32(3)]));
+    assert_eq!(Bson::from(json!({"_id": {"$oid": oid.to_hex()}, "name": ["bson-rs"]})), Bson::Document(doc!{"_id": &oid, "name": ["bson-rs"]}));
+
+    // References
+    assert_eq!(Bson::from(&24i32), Bson::I32(24));
+    assert_eq!(Bson::from(&String::from("data")), Bson::String(String::from("data")));
+    assert_eq!(Bson::from(&oid), Bson::ObjectId(oid));
+    assert_eq!(Bson::from(&doc!{"a": "b"}), Bson::Document(doc!{"a": "b"}));
+
 }


### PR DESCRIPTION
This PR new `From<>` implementations to Bson to cover `Vec<T>`, &[T] objects, and &T (where T implements Into<Bson> + Clone).  Comparable impls exist in serde_json::Value, which is, I think, a good reference point for how the Bson type should operate.  Having these impls in place eliminates a lot of manual cloning.

Caveat: When using this branch in the mongodb crate, there is one type inference break:  Because the `From<Array>` implementation (== `From<Vec<Bson>>`) was replaced by `From<Vec<T>> where T: Into<Bson>`, `Bson::from(Vec::new())` now complains that it needs to know the full type of `Vec::new()`.  The problem is resolved by using `Bson::Array(Vec::new())` instead of `Bson::from`.  It also only shows up in case of a Vec of unspecified type, which means it should not affect conversion from a struct member in most cases.  Again, this behavior is [in line with how `serde_json::Value` operates](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=8325d9b6e0df3fb1b50e763843069096).