### PR TITLE
Clean macro imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,6 @@ bson = "0.14"
 ```
 
 ## Usage
-Link the library in _main.rs_:
-
-```rust
-#[macro_use(bson, doc)]
-extern crate bson;
-```
 
 Prepare your struct for Serde serialization:
 
@@ -63,6 +57,8 @@ if let bson::Bson::Document(document) = serialized_person {
 Deserialize the struct:
 
 ```rust
+use bson::doc;
+
 // Read the document from a MongoDB collection
 let person_document = mongoCollection.find_one(Some(doc! { "_id":  bson::oid::ObjectId::with_string("12345").expect("Id not valid") }), None)?
     .expect("Document not found");

--- a/examples/decode.rs
+++ b/examples/decode.rs
@@ -1,4 +1,4 @@
-extern crate bson;
+use bson;
 
 use std::fs::File;
 

--- a/examples/encode.rs
+++ b/examples/encode.rs
@@ -1,8 +1,8 @@
-extern crate bson;
-extern crate chrono;
+
+use std::io::Cursor;
 
 use bson::{decode_document, encode_document, oid, Array, Bson, Document};
-use std::io::Cursor;
+use chrono;
 
 fn main() {
     let mut doc = Document::new();

--- a/serde-tests/Cargo.toml
+++ b/serde-tests/Cargo.toml
@@ -2,11 +2,11 @@
 name = "serde-tests"
 version = "0.1.0"
 authors = ["Kevin Yeh <kevinyeah@utexas.edu>"]
+edition = "2018"
 
 [dependencies]
-serde = "1.0"
 bson = { path = ".." }
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 
 [lib]
 name = "serde_tests"

--- a/serde-tests/test.rs
+++ b/serde-tests/test.rs
@@ -1,7 +1,3 @@
-extern crate bson;
-extern crate serde;
-#[macro_use] extern crate serde_derive;
-
 use std::collections::{BTreeMap, HashSet};
 use serde::{Deserialize, Serialize, Deserializer};
 use serde::de::Unexpected;

--- a/src/bson.rs
+++ b/src/bson.rs
@@ -27,7 +27,7 @@ use std::ops::{Deref, DerefMut};
 use chrono::offset::TimeZone;
 use chrono::{DateTime, Timelike, Utc};
 use hex;
-use serde_json::Value;
+use serde_json::{Value, json};
 
 #[cfg(feature = "decimal128")]
 use crate::decimal128::Decimal128;
@@ -751,7 +751,6 @@ impl Bson {
 ///
 /// ```rust,ignore
 /// use serde::{Serialize, Deserialize};
-/// extern crate bson;
 /// use bson::TimeStamp;
 ///
 /// #[derive(Serialize, Deserialize)]
@@ -770,9 +769,7 @@ pub struct TimeStamp {
 /// Just a helper for convenience
 ///
 /// ```rust,ignore
-/// #[macro_use]
-/// extern crate serde_derive;
-/// extern crate bson;
+/// use serde::{Serialize, Deserialize};
 /// use bson::UtcDateTime;
 ///
 /// #[derive(Serialize, Deserialize)]

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -37,7 +37,7 @@ use chrono::Timelike;
 use crate::bson::Bson;
 #[cfg(feature = "decimal128")]
 use crate::decimal128::Decimal128;
-use crate::serde::Serialize;
+use ::serde::Serialize;
 
 fn write_string<W: Write + ?Sized>(writer: &mut W, s: &str) -> EncoderResult<()> {
     writer.write_i32::<LittleEndian>(s.len() as i32 + 1)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,6 @@
 //! ## Basic usage
 //!
 //! ```rust
-//! extern crate bson;
 //! use bson::{decode_document, encode_document, Bson, Document};
 //! use std::io::Cursor;
 //!
@@ -42,18 +41,6 @@
 //! }
 //! ```
 
-extern crate byteorder;
-extern crate chrono;
-extern crate hex;
-extern crate linked_hash_map;
-extern crate rand;
-extern crate serde;
-#[macro_use]
-extern crate serde_json;
-#[cfg(feature = "decimal128")]
-extern crate decimal;
-extern crate md5;
-extern crate time;
 
 pub use self::bson::{Array, Bson, Document, TimeStamp, UtcDateTime};
 #[cfg(feature = "decimal128")]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -3,8 +3,7 @@
 /// Construct a bson::BSON value from a literal.
 ///
 /// ```rust
-/// # #[macro_use]
-/// # extern crate bson;
+/// # use bson::bson;
 /// #
 /// # fn main() {
 /// let value = bson!({
@@ -40,32 +39,32 @@ macro_rules! bson {
 
     // Next element is `null`.
     (@array [$($elems:expr,)*] null $($rest:tt)*) => {
-        bson!(@array [$($elems,)* bson!(null)] $($rest)*)
+        $crate::bson!(@array [$($elems,)* $crate::bson!(null)] $($rest)*)
     };
 
     // Next element is an array.
     (@array [$($elems:expr,)*] [$($array:tt)*] $($rest:tt)*) => {
-        bson!(@array [$($elems,)* bson!([$($array)*])] $($rest)*)
+        $crate::bson!(@array [$($elems,)* $crate::bson!([$($array)*])] $($rest)*)
     };
 
     // Next element is a map.
     (@array [$($elems:expr,)*] {$($map:tt)*} $($rest:tt)*) => {
-        bson!(@array [$($elems,)* bson!({$($map)*})] $($rest)*)
+        $crate::bson!(@array [$($elems,)* $crate::bson!({$($map)*})] $($rest)*)
     };
 
     // Next element is an expression followed by comma.
     (@array [$($elems:expr,)*] $next:expr, $($rest:tt)*) => {
-        bson!(@array [$($elems,)* bson!($next),] $($rest)*)
+        $crate::bson!(@array [$($elems,)* $crate::bson!($next),] $($rest)*)
     };
 
     // Last element is an expression with no trailing comma.
     (@array [$($elems:expr,)*] $last:expr) => {
-        bson!(@array [$($elems,)* bson!($last)])
+        $crate::bson!(@array [$($elems,)* $crate::bson!($last)])
     };
 
     // Comma after the most recent element.
     (@array [$($elems:expr),*] , $($rest:tt)*) => {
-        bson!(@array [$($elems,)*] $($rest)*)
+        $crate::bson!(@array [$($elems,)*] $($rest)*)
     };
 
     //////////////////////////////////////////////////////////////////////////
@@ -84,7 +83,7 @@ macro_rules! bson {
     // Insert the current entry followed by trailing comma.
     (@object $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
         $object.insert_bson(($($key)+).into(), $value);
-        bson!(@object $object () ($($rest)*) ($($rest)*));
+        $crate::bson!(@object $object () ($($rest)*) ($($rest)*));
     };
 
     // Insert the last entry without trailing comma.
@@ -94,65 +93,65 @@ macro_rules! bson {
 
     // Next value is `null`.
     (@object $object:ident ($($key:tt)+) (=> null $($rest:tt)*) $copy:tt) => {
-        bson!(@object $object [$($key)+] (bson!(null)) $($rest)*);
+        $crate::bson!(@object $object [$($key)+] ($crate::bson!(null)) $($rest)*);
     };
 
     (@object $object:ident ($($key:tt)+) (: null $($rest:tt)*) $copy:tt) => {
-        bson!(@object $object [$($key)+] (bson!(null)) $($rest)*);
+        $crate::bson!(@object $object [$($key)+] ($crate::bson!(null)) $($rest)*);
     };
 
     // Next value is an array.
     (@object $object:ident ($($key:tt)+) (=> [$($array:tt)*] $($rest:tt)*) $copy:tt) => {
-        bson!(@object $object [$($key)+] (bson!([$($array)*])) $($rest)*);
+        $crate::bson!(@object $object [$($key)+] ($crate::bson!([$($array)*])) $($rest)*);
     };
 
     (@object $object:ident ($($key:tt)+) (: [$($array:tt)*] $($rest:tt)*) $copy:tt) => {
-        bson!(@object $object [$($key)+] (bson!([$($array)*])) $($rest)*);
+        $crate::bson!(@object $object [$($key)+] ($crate::bson!([$($array)*])) $($rest)*);
     };
 
     // Next value is a map.
     (@object $object:ident ($($key:tt)+) (=> {$($map:tt)*} $($rest:tt)*) $copy:tt) => {
-        bson!(@object $object [$($key)+] (bson!({$($map)*})) $($rest)*);
+        $crate::bson!(@object $object [$($key)+] ($crate::bson!({$($map)*})) $($rest)*);
     };
 
     (@object $object:ident ($($key:tt)+) (: {$($map:tt)*} $($rest:tt)*) $copy:tt) => {
-        bson!(@object $object [$($key)+] (bson!({$($map)*})) $($rest)*);
+        $crate::bson!(@object $object [$($key)+] ($crate::bson!({$($map)*})) $($rest)*);
     };
 
     // Next value is an expression followed by comma.
     (@object $object:ident ($($key:tt)+) (=> $value:expr , $($rest:tt)*) $copy:tt) => {
-        bson!(@object $object [$($key)+] (bson!($value)) , $($rest)*);
+        $crate::bson!(@object $object [$($key)+] ($crate::bson!($value)) , $($rest)*);
     };
 
     (@object $object:ident ($($key:tt)+) (: $value:expr , $($rest:tt)*) $copy:tt) => {
-        bson!(@object $object [$($key)+] (bson!($value)) , $($rest)*);
+        $crate::bson!(@object $object [$($key)+] ($crate::bson!($value)) , $($rest)*);
     };
 
     // Last value is an expression with no trailing comma.
     (@object $object:ident ($($key:tt)+) (=> $value:expr) $copy:tt) => {
-        bson!(@object $object [$($key)+] (bson!($value)));
+        $crate::bson!(@object $object [$($key)+] ($crate::bson!($value)));
     };
 
     (@object $object:ident ($($key:tt)+) (: $value:expr) $copy:tt) => {
-        bson!(@object $object [$($key)+] (bson!($value)));
+        $crate::bson!(@object $object [$($key)+] ($crate::bson!($value)));
     };
 
     // Missing value for last entry. Trigger a reasonable error message.
     (@object $object:ident ($($key:tt)+) (=>) $copy:tt) => {
         // "unexpected end of macro invocation"
-        bson!();
+        $crate::bson!();
     };
 
     (@object $object:ident ($($key:tt)+) (:) $copy:tt) => {
         // "unexpected end of macro invocation"
-        bson!();
+        $crate::bson!();
     };
 
     // Missing key-value separator and value for last entry.
     // Trigger a reasonable error message.
     (@object $object:ident ($($key:tt)+) () $copy:tt) => {
         // "unexpected end of macro invocation"
-        bson!();
+        $crate::bson!();
     };
 
     // Misplaced key-value separator. Trigger a reasonable error message.
@@ -175,16 +174,16 @@ macro_rules! bson {
     // Key is fully parenthesized. This avoids clippy double_parens false
     // positives because the parenthesization may be necessary here.
     (@object $object:ident () (($key:expr) => $($rest:tt)*) $copy:tt) => {
-        bson!(@object $object ($key) (=> $($rest)*) (=> $($rest)*));
+        $crate::bson!(@object $object ($key) (=> $($rest)*) (=> $($rest)*));
     };
 
     (@object $object:ident () (($key:expr) : $($rest:tt)*) $copy:tt) => {
-        bson!(@object $object ($key) (: $($rest)*) (: $($rest)*));
+        $crate::bson!(@object $object ($key) (: $($rest)*) (: $($rest)*));
     };
 
     // Munch a token into the current key.
     (@object $object:ident ($($key:tt)*) ($tt:tt $($rest:tt)*) $copy:tt) => {
-        bson!(@object $object ($($key)* $tt) ($($rest)*) ($($rest)*));
+        $crate::bson!(@object $object ($($key)* $tt) ($($rest)*) ($($rest)*));
     };
 
     //////////////////////////////////////////////////////////////////////////
@@ -202,15 +201,15 @@ macro_rules! bson {
     };
 
     ([ $($tt:tt)+ ]) => {
-        $crate::Bson::Array(bson!(@array [] $($tt)+))
+        $crate::Bson::Array($crate::bson!(@array [] $($tt)+))
     };
 
     ({}) => {
-        $crate::Bson::Document(doc!{})
+        $crate::Bson::Document($crate::doc!{})
     };
 
     ({$($tt:tt)+}) => {
-        $crate::Bson::Document(doc!{$($tt)+});
+        $crate::Bson::Document($crate::doc!{$($tt)+});
     };
 
     // Any Serialize type: numbers, strings, struct literals, variables etc.
@@ -223,8 +222,7 @@ macro_rules! bson {
 /// Construct a bson::Document value.
 ///
 /// ```rust
-/// # #[macro_use]
-/// # extern crate bson;
+/// # use bson::doc;
 /// #
 /// # fn main() {
 /// let value = doc! {
@@ -244,7 +242,7 @@ macro_rules! doc {
     () => {{ $crate::Document::new() }};
     ( $($tt:tt)+ ) => {{
         let mut object = $crate::Document::new();
-        bson!(@object object () ($($tt)+) ($($tt)+));
+        $crate::bson!(@object object () ($($tt)+) ($($tt)+));
         object
     }};
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,11 +1,1 @@
-#[macro_use(assert_matches)]
-extern crate assert_matches;
-#[macro_use(bson, doc)]
-extern crate bson;
-extern crate byteorder;
-extern crate chrono;
-#[cfg(feature = "decimal128")]
-extern crate decimal;
-extern crate hex;
-
 mod modules;

--- a/tests/modules/bson.rs
+++ b/tests/modules/bson.rs
@@ -1,7 +1,5 @@
-extern crate serde_json;
-
-use self::serde_json::{Value, json};
-use bson::{Bson, Document, oid::ObjectId, spec::BinarySubtype};
+use serde_json::{Value, json};
+use bson::{Bson, Document, doc, oid::ObjectId, spec::BinarySubtype};
 
 #[test]
 fn to_json() {

--- a/tests/modules/encoder_decoder.rs
+++ b/tests/modules/encoder_decoder.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "decimal128")]
 use bson::decimal128::Decimal128;
+use bson::doc;
 use bson::oid::ObjectId;
 use bson::spec::BinarySubtype;
 use bson::{decode_document, decode_document_utf8_lossy, encode_document, Bson};

--- a/tests/modules/macros.rs
+++ b/tests/modules/macros.rs
@@ -1,6 +1,7 @@
 use bson::oid::ObjectId;
 use bson::spec::BinarySubtype;
 use bson::Bson;
+use bson::doc;
 use chrono::offset::Utc;
 use hex;
 

--- a/tests/modules/ordered.rs
+++ b/tests/modules/ordered.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "decimal128")]
 use bson::decimal128::Decimal128;
+use bson::doc;
 use bson::oid::ObjectId;
 use bson::spec::BinarySubtype;
 use bson::ValueAccessError;

--- a/tests/modules/ser.rs
+++ b/tests/modules/ser.rs
@@ -1,3 +1,4 @@
+use assert_matches::assert_matches;
 #[cfg(feature = "decimal128")]
 use bson::decimal128::Decimal128;
 use bson::oid::ObjectId;

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,13 +1,6 @@
-#[macro_use]
-extern crate bson;
-extern crate chrono;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_bytes;
-
-use bson::{Bson, Decoder, Encoder};
+use bson::{Bson, Decoder, Encoder, bson, doc};
 use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 use std::collections::BTreeMap;
 


### PR DESCRIPTION
Allow bson! and doc! macros to work without importing both.

Also update imports and documentation to work without using extern crate everywhere.

I didn't update the fuzz tests because I'm not sure how they're run, so I wouldn't be able to test them properly.
